### PR TITLE
update base_token_uri and freeze

### DIFF
--- a/contracts/sg721/schema/execute_msg.json
+++ b/contracts/sg721/schema/execute_msg.json
@@ -19,10 +19,10 @@
       "description": "Update token uris for all tokens \"{base_token_uri}/{token_id}\"",
       "type": "object",
       "required": [
-        "update_token_u_r_is"
+        "update_token_uris"
       ],
       "properties": {
-        "update_token_u_r_is": {
+        "update_token_uris": {
           "type": "object",
           "required": [
             "base_token_uri"

--- a/contracts/sg721/schema/execute_msg.json
+++ b/contracts/sg721/schema/execute_msg.json
@@ -3,6 +3,19 @@
   "title": "ExecuteMsg",
   "oneOf": [
     {
+      "description": "Freeze contract from updating token uris",
+      "type": "object",
+      "required": [
+        "freeze"
+      ],
+      "properties": {
+        "freeze": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
       "description": "Update token uris for all tokens \"{base_token_uri}/{token_id}\"",
       "type": "object",
       "required": [

--- a/contracts/sg721/schema/execute_msg.json
+++ b/contracts/sg721/schema/execute_msg.json
@@ -1,8 +1,28 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "ExecuteMsg_for_Empty",
-  "description": "This is like Cw721ExecuteMsg but we add a Mint command for an owner to make this stand-alone. You will likely want to remove mint and use other control logic in any contract that inherits this.",
+  "title": "ExecuteMsg",
   "oneOf": [
+    {
+      "description": "Update token uris for all tokens \"{base_token_uri}/{token_id}\"",
+      "type": "object",
+      "required": [
+        "update_token_u_r_is"
+      ],
+      "properties": {
+        "update_token_u_r_is": {
+          "type": "object",
+          "required": [
+            "base_token_uri"
+          ],
+          "properties": {
+            "base_token_uri": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     {
       "description": "Transfer is a base message to move a token to another account without triggering actions",
       "type": "object",

--- a/contracts/sg721/src/contract.rs
+++ b/contracts/sg721/src/contract.rs
@@ -9,7 +9,6 @@ use sg_std::StargazeMsgWrapper;
 use crate::ContractError;
 use cw721::ContractInfoResponse;
 use cw721_base::ContractError as BaseError;
-use cw721_base::TokenInfo as Cw721TokenInfo;
 use url::Url;
 
 use crate::msg::{
@@ -94,23 +93,22 @@ pub fn instantiate(
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(
     deps: DepsMut,
-    env: Env,
+    _env: Env,
     info: MessageInfo,
     msg: ExecuteMsg,
 ) -> Result<Response, BaseError> {
     match msg {
         ExecuteMsg::UpdateTokenURIs { base_token_uri } => {
-            execute_update_token_uris(deps, env, info, base_token_uri)
+            execute_update_token_uris(deps, info, base_token_uri)
         }
-        //TODO change back to Sg721Contract
+        // TODO add back Sg721Contract::default() msgs
         // _ => Sg721Contract::default().execute(deps, env, info, msg),
-        _ => Ok(Response::default()),
+        _ => Ok(Response::new()),
     }
 }
 
 fn execute_update_token_uris(
     deps: DepsMut,
-    env: Env,
     info: MessageInfo,
     base_token_uri: String,
 ) -> Result<Response, BaseError> {
@@ -131,14 +129,14 @@ fn execute_update_token_uris(
 
     sg721_contract
         .tokens
-        .update(deps.storage, &token_id, |token| match token {
+        .update(deps.storage, &token_id.clone(), |token| match token {
             Some(mut token_info) => {
                 token_info.token_uri = Some(format!("{}/{}", base_token_uri, token_id));
                 token_info.extension = Empty {};
                 Ok(token_info)
             }
             None => return Err(ContractError::TokenNotFound { got: token_id }),
-        });
+        })?;
     Ok(Response::new())
 }
 

--- a/contracts/sg721/src/contract.rs
+++ b/contracts/sg721/src/contract.rs
@@ -101,9 +101,7 @@ pub fn execute(
         ExecuteMsg::UpdateTokenURIs { base_token_uri } => {
             execute_update_token_uris(deps, info, base_token_uri)
         }
-        // TODO add back Sg721Contract::default() msgs
-        // _ => Sg721Contract::default().execute(deps, env, info, msg),
-        _ => Ok(Response::new()),
+        _ => Sg721Contract::default().execute(deps, _env, info, msg.into()),
     }
 }
 

--- a/contracts/sg721/src/contract.rs
+++ b/contracts/sg721/src/contract.rs
@@ -97,7 +97,22 @@ pub fn execute(
     info: MessageInfo,
     msg: ExecuteMsg,
 ) -> Result<Response, BaseError> {
-    Sg721Contract::default().execute(deps, env, info, msg)
+    match msg {
+        ExecuteMsg::UpdateTokenURIs { base_token_uri } => {
+            execute_update_token_uris(deps, env, info, base_token_uri)
+        }
+        _ => Sg721Contract::default().execute(deps, env, info, msg),
+    }
+}
+
+fn execute_update_token_uris(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    base_token_uri: String,
+) -> Result<Response, BaseError> {
+    // Sg721Contract::default().tokens.update(desp.storage,&token_id, &msg)
+    Ok(Response::new())
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/sg721/src/contract.rs
+++ b/contracts/sg721/src/contract.rs
@@ -98,7 +98,7 @@ pub fn execute(
     _env: Env,
     info: MessageInfo,
     msg: ExecuteMsg,
-) -> Result<Response, BaseError> {
+) -> Result<Response, ContractError> {
     match msg {
         ExecuteMsg::Freeze {} => execute_freeze(deps, info),
         ExecuteMsg::UpdateTokenURIs { base_token_uri } => {
@@ -108,12 +108,12 @@ pub fn execute(
     }
 }
 
-fn execute_freeze(deps: DepsMut, info: MessageInfo) -> Result<Response, BaseError> {
+fn execute_freeze(deps: DepsMut, info: MessageInfo) -> Result<Response, ContractError> {
     let sg721_contract = Sg721Contract::default();
     let minter = sg721_contract.minter.load(deps.storage)?;
 
     if info.sender != minter {
-        return Err(BaseError::Unauthorized {});
+        return Err(ContractError::Unauthorized {});
     }
 
     FROZEN.save(deps.storage, &true)?;
@@ -124,13 +124,13 @@ fn execute_update_token_uris(
     deps: DepsMut,
     info: MessageInfo,
     base_token_uri: String,
-) -> Result<Response, BaseError> {
+) -> Result<Response, ContractError> {
     let sg721_contract = Sg721Contract::default();
     let minter = sg721_contract.minter.load(deps.storage)?;
     let frozen = FROZEN.load(deps.storage)?;
 
     if info.sender != minter {
-        return Err(BaseError::Unauthorized {});
+        return Err(ContractError::Unauthorized {});
     }
 
     if frozen {

--- a/contracts/sg721/src/contract.rs
+++ b/contracts/sg721/src/contract.rs
@@ -307,7 +307,7 @@ mod tests {
         let _ = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
         // mint nft
-        let token_id = "1".to_string();
+        let token_id = "copypasta".to_string();
         let token_uri = "https://www.merriam-webster.com/dictionary/petrify".to_string();
 
         let exec_mint_msg = Cw721ExecuteMsg::Mint(MintMsg::<Empty> {

--- a/contracts/sg721/src/contract.rs
+++ b/contracts/sg721/src/contract.rs
@@ -133,7 +133,7 @@ fn execute_update_token_uris(
                 token_info.extension = Empty {};
                 Ok(token_info)
             }
-            None => return Err(ContractError::TokenNotFound { got: token_id }),
+            None => Err(ContractError::TokenNotFound { got: token_id }),
         })?;
     Ok(Response::new())
 }
@@ -299,7 +299,7 @@ mod tests {
         // confirm response is the same
         let res: NftInfoResponse<Empty> =
             from_binary(&query(deps.as_ref(), mock_env(), query_msg.clone()).unwrap()).unwrap();
-        assert_eq!(res.token_uri, Some(token_uri.clone()));
+        assert_eq!(res.token_uri, Some(token_uri));
 
         // update base token uri
         let new_base_token_uri: String = "ipfs://new_base_token_uri_hash".to_string();

--- a/contracts/sg721/src/contract.rs
+++ b/contracts/sg721/src/contract.rs
@@ -9,6 +9,7 @@ use sg_std::StargazeMsgWrapper;
 use crate::ContractError;
 use cw721::ContractInfoResponse;
 use cw721_base::ContractError as BaseError;
+use cw721_base::TokenInfo as Cw721TokenInfo;
 use url::Url;
 
 use crate::msg::{
@@ -101,7 +102,9 @@ pub fn execute(
         ExecuteMsg::UpdateTokenURIs { base_token_uri } => {
             execute_update_token_uris(deps, env, info, base_token_uri)
         }
-        _ => Sg721Contract::default().execute(deps, env, info, msg),
+        //TODO change back to Sg721Contract
+        // _ => Sg721Contract::default().execute(deps, env, info, msg),
+        _ => Ok(Response::default()),
     }
 }
 
@@ -111,7 +114,28 @@ fn execute_update_token_uris(
     info: MessageInfo,
     base_token_uri: String,
 ) -> Result<Response, BaseError> {
-    // Sg721Contract::default().tokens.update(desp.storage,&token_id, &msg)
+    let minter = Sg721Contract::default().minter.load(deps.storage)?;
+    // TODO add frozen state
+    // let frozen = FROZEN.load(deps.storage)?;
+    if info.sender != minter {
+        Err(BaseError::Unauthorized {});
+    }
+
+    // TODO add frozen state check
+    // if frozen {
+    //     Err(ContractError::Frozen {});
+    // }
+
+    let token_id = "1".to_string();
+    let msg = Cw721MintMsg {
+        token_id,
+        owner: "asdfasdf".to_string(),
+        token_uri: Some(format!("{}/{}", base_token_uri, token_id)),
+        extension: None,
+    };
+    Sg721Contract::default()
+        .tokens
+        .update(deps.storage, &"1", &msg);
     Ok(Response::new())
 }
 

--- a/contracts/sg721/src/contract.rs
+++ b/contracts/sg721/src/contract.rs
@@ -9,7 +9,6 @@ use sg_std::StargazeMsgWrapper;
 use crate::state::FROZEN;
 use crate::ContractError;
 use cw721::ContractInfoResponse;
-use cw721_base::ContractError as BaseError;
 use url::Url;
 
 use crate::msg::{
@@ -104,7 +103,9 @@ pub fn execute(
         ExecuteMsg::UpdateTokenURIs { base_token_uri } => {
             execute_update_token_uris(deps, info, base_token_uri)
         }
-        _ => Sg721Contract::default().execute(deps, _env, info, msg.into()),
+        _ => Sg721Contract::default()
+            .execute(deps, _env, info, msg.into())
+            .map_err(ContractError::from),
     }
 }
 
@@ -338,6 +339,9 @@ mod tests {
         );
 
         // freeze contract
+        let freeze_msg = ExecuteMsg::Freeze {};
+        let _ = execute(deps.as_mut(), mock_env(), allowed.clone(), freeze_msg).unwrap();
+
         let even_newer_base_token_uri: String = "ipfs://even_newer_base_token_uri_hash".to_string();
         let exec_update_token_uris_msg = ExecuteMsg::UpdateTokenURIs {
             base_token_uri: even_newer_base_token_uri.clone(),

--- a/contracts/sg721/src/contract.rs
+++ b/contracts/sg721/src/contract.rs
@@ -344,7 +344,7 @@ mod tests {
 
         let even_newer_base_token_uri: String = "ipfs://even_newer_base_token_uri_hash".to_string();
         let exec_update_token_uris_msg = ExecuteMsg::UpdateTokenURIs {
-            base_token_uri: even_newer_base_token_uri.clone(),
+            base_token_uri: even_newer_base_token_uri,
         };
         // error when trying to update token_uri after freeze
         let err = execute(

--- a/contracts/sg721/src/contract.rs
+++ b/contracts/sg721/src/contract.rs
@@ -279,7 +279,7 @@ mod tests {
         println!("{:?}", res);
 
         // mint nft
-        let token_id = "petrify".to_string();
+        let token_id = "1".to_string();
         let token_uri = "https://www.merriam-webster.com/dictionary/petrify".to_string();
 
         let exec_mint_msg = Cw721ExecuteMsg::Mint(MintMsg::<Empty> {
@@ -291,7 +291,7 @@ mod tests {
 
         let allowed = mock_info(MINTER, &[]);
         let _ = Sg721Contract::default()
-            .execute(deps.as_mut(), mock_env(), allowed, exec_mint_msg)
+            .execute(deps.as_mut(), mock_env(), allowed.clone(), exec_mint_msg)
             .unwrap();
 
         let query_msg: QueryMsg = QueryMsg::NftInfo {
@@ -300,7 +300,7 @@ mod tests {
 
         // confirm response is the same
         let res: NftInfoResponse<Empty> =
-            from_binary(&query(deps.as_ref(), mock_env(), query_msg).unwrap()).unwrap();
+            from_binary(&query(deps.as_ref(), mock_env(), query_msg.clone()).unwrap()).unwrap();
         assert_eq!(res.token_uri, Some(token_uri.clone()));
 
         // update base token uri
@@ -308,15 +308,20 @@ mod tests {
         let exec_update_token_uris_msg = ExecuteMsg::UpdateTokenURIs {
             base_token_uri: new_base_token_uri.clone(),
         };
-        let _ = Sg721Contract::default()
-            .execute(
-                deps.as_mut(),
-                mock_env(),
-                allowed,
-                exec_update_token_uris_msg,
-            )
-            .unwrap();
+        let _ = execute(
+            deps.as_mut(),
+            mock_env(),
+            allowed,
+            exec_update_token_uris_msg,
+        )
+        .unwrap();
 
-        // assert_eq!(token_uri, format!("{}/{}", new_base_token_uri, token_id))
+        let res: NftInfoResponse<Empty> =
+            from_binary(&query(deps.as_ref(), mock_env(), query_msg).unwrap()).unwrap();
+
+        assert_eq!(
+            res.token_uri,
+            Some(format!("{}/{}", new_base_token_uri, token_id))
+        )
     }
 }

--- a/contracts/sg721/src/error.rs
+++ b/contracts/sg721/src/error.rs
@@ -1,5 +1,4 @@
 use cosmwasm_std::StdError;
-use cw721_base::ContractError as Cw721ContractError;
 use cw_utils::PaymentError;
 use sg_std::FeeError;
 use thiserror::Error;
@@ -34,6 +33,9 @@ pub enum ContractError {
     #[error("Cannot update token uri after contract freeze")]
     Frozen {},
 
+    #[error("{0}")]
+    BaseError(cw721_base::ContractError),
+
     #[error["Token id not found {got}"]]
     TokenNotFound { got: String },
 
@@ -47,13 +49,13 @@ pub enum ContractError {
     Parse(#[from] ParseError),
 }
 
-impl From<ContractError> for Cw721ContractError {
-    fn from(err: ContractError) -> Cw721ContractError {
+impl From<cw721_base::ContractError> for ContractError {
+    fn from(err: cw721_base::ContractError) -> Self {
         match err {
-            ContractError::Unauthorized {} => Cw721ContractError::Unauthorized {},
-            ContractError::Claimed {} => Cw721ContractError::Claimed {},
-            ContractError::Expired {} => Cw721ContractError::Expired {},
-            _ => unreachable!("cannot convert {:?} to Cw721ContractError", err),
+            cw721_base::ContractError::Unauthorized {} => Self::Unauthorized {},
+            cw721_base::ContractError::Claimed {} => Self::Claimed {},
+            cw721_base::ContractError::Expired {} => Self::Expired {},
+            err => Self::BaseError(err),
         }
     }
 }

--- a/contracts/sg721/src/error.rs
+++ b/contracts/sg721/src/error.rs
@@ -31,6 +31,12 @@ pub enum ContractError {
     #[error("Description too long")]
     DescriptionTooLong {},
 
+    #[error("Cannot update token uri after contract freeze")]
+    Frozen {},
+
+    #[error["Token id not found {got}"]]
+    TokenNotFound { got: String },
+
     #[error("{0}")]
     Payment(#[from] PaymentError),
 

--- a/contracts/sg721/src/msg.rs
+++ b/contracts/sg721/src/msg.rs
@@ -106,7 +106,7 @@ impl From<ExecuteMsg> for Cw721ExecuteMsg<Empty> {
                 Cw721ExecuteMsg::ApproveAll { operator, expires }
             }
             ExecuteMsg::RevokeAll { operator } => Cw721ExecuteMsg::RevokeAll { operator },
-            ExecuteMsg::Mint(mint_msg) => Cw721ExecuteMsg::Mint(mint_msg.into()),
+            ExecuteMsg::Mint(mint_msg) => Cw721ExecuteMsg::Mint(mint_msg),
             ExecuteMsg::Burn { token_id } => Cw721ExecuteMsg::Burn { token_id },
             _ => unreachable!("cannot convert {:?} to Cw721ExecuteMsg", msg),
         }

--- a/contracts/sg721/src/msg.rs
+++ b/contracts/sg721/src/msg.rs
@@ -36,6 +36,7 @@ pub enum ExecuteMsg {
     /// Freeze contract from updating token uris
     Freeze {},
     /// Update token uris for all tokens "{base_token_uri}/{token_id}"
+    #[serde(rename = "update_token_uris")]
     UpdateTokenURIs { base_token_uri: String },
     /// Transfer is a base message to move a token to another account without triggering actions
     TransferNft { recipient: String, token_id: String },

--- a/contracts/sg721/src/msg.rs
+++ b/contracts/sg721/src/msg.rs
@@ -33,6 +33,8 @@ impl RoyaltyInfoResponse {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
+    /// Freeze contract from updating token uris
+    Freeze {},
     /// Update token uris for all tokens "{base_token_uri}/{token_id}"
     UpdateTokenURIs { base_token_uri: String },
     /// Transfer is a base message to move a token to another account without triggering actions

--- a/contracts/sg721/src/msg.rs
+++ b/contracts/sg721/src/msg.rs
@@ -1,8 +1,6 @@
 use crate::{state::CollectionInfo, ContractError};
 use cosmwasm_std::{Binary, Decimal, Empty};
-use cw721_base::msg::{
-    ExecuteMsg as Cw721ExecuteMsg, MintMsg as Cw721MintMsg, QueryMsg as Cw721QueryMsg,
-};
+use cw721_base::msg::{ExecuteMsg as Cw721ExecuteMsg, MintMsg, QueryMsg as Cw721QueryMsg};
 use cw_utils::Expiration;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -65,7 +63,7 @@ pub enum ExecuteMsg {
     RevokeAll { operator: String },
 
     /// Mint a new NFT, can only be called by the contract minter
-    Mint(Cw721MintMsg<Empty>),
+    Mint(MintMsg<Empty>),
 
     /// Burn an NFT the sender has access to
     Burn { token_id: String },

--- a/contracts/sg721/src/msg.rs
+++ b/contracts/sg721/src/msg.rs
@@ -1,6 +1,8 @@
 use crate::{state::CollectionInfo, ContractError};
 use cosmwasm_std::{Decimal, Empty};
-use cw721_base::msg::QueryMsg as Cw721QueryMsg;
+use cw721_base::msg::{
+    ExecuteMsg as Cw721ExecuteMsg, MintMsg as Cw721MintMsg, QueryMsg as Cw721QueryMsg,
+};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -28,7 +30,20 @@ impl RoyaltyInfoResponse {
     }
 }
 
-pub type ExecuteMsg = cw721_base::ExecuteMsg<Empty>;
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecuteMsg {
+    UpdateTokenURIs { base_token_uri: String },
+    Mint(Cw721MintMsg<Empty>),
+}
+impl From<ExecuteMsg> for Cw721ExecuteMsg<Empty> {
+    fn from(msg: ExecuteMsg) -> Cw721ExecuteMsg<Empty> {
+        match msg {
+            ExecuteMsg::Mint(Cw721MintMsg) => Cw721ExecuteMsg::Mint(Cw721MintMsg),
+            _ => unreachable!("cannot convert {:?} to Cw721ExecuteMsg", msg),
+        }
+    }
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]

--- a/contracts/sg721/src/msg.rs
+++ b/contracts/sg721/src/msg.rs
@@ -30,6 +30,7 @@ impl RoyaltyInfoResponse {
     }
 }
 
+// TODO add other msgs from cw721
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
@@ -39,7 +40,7 @@ pub enum ExecuteMsg {
 impl From<ExecuteMsg> for Cw721ExecuteMsg<Empty> {
     fn from(msg: ExecuteMsg) -> Cw721ExecuteMsg<Empty> {
         match msg {
-            ExecuteMsg::Mint(Cw721MintMsg) => Cw721ExecuteMsg::Mint(Cw721MintMsg),
+            ExecuteMsg::Mint(cw721_mint_msg) => Cw721ExecuteMsg::Mint(cw721_mint_msg),
             _ => unreachable!("cannot convert {:?} to Cw721ExecuteMsg", msg),
         }
     }

--- a/contracts/sg721/src/state.rs
+++ b/contracts/sg721/src/state.rs
@@ -19,3 +19,4 @@ pub struct RoyaltyInfo {
 }
 
 pub const COLLECTION_INFO: Item<CollectionInfo<RoyaltyInfo>> = Item::new("collection_info");
+pub const FROZEN: Item<bool> = Item::new("frozen");


### PR DESCRIPTION
fix #180 

1. Creator starts with a base token uri pointing to blank metadata pointing to the same initial teaser image. 
2. Minting happens.
3. Creator reveals later by updating base token uri pointing to final metadata and images.
4. Creator later freezes metadata so it can not be further updated.

- swapped `from` error messages around so `cw721_base::ContractError` is transformed into `ContractError`
- message type can be tricky. Needed to extend and then implement all the cw721_base execute msgs