### PR TITLE
working token index

### DIFF
--- a/contracts/minter/src/contract.rs
+++ b/contracts/minter/src/contract.rs
@@ -6,7 +6,7 @@ use crate::msg::{
     MintableNumTokensResponse, QueryMsg, StartTimeResponse,
 };
 use crate::state::{
-    decrement_tokens, increment_tokens, token_count, tokens, Config, TokenInfo, CONFIG,
+    decrement_tokens, token_count, tokens, Config, TokenInfo, CONFIG, MINTABLE_NUM_TOKENS,
     MINTER_ADDRS, SG721_ADDRESS,
 };
 #[cfg(not(feature = "library"))]
@@ -121,17 +121,19 @@ pub fn instantiate(
         start_time: msg.start_time,
     };
     CONFIG.save(deps.storage, &config)?;
+    MINTABLE_NUM_TOKENS.save(deps.storage, &msg.num_tokens)?;
 
     let token_list = random_token_list(&env, msg.num_tokens)?;
     // Save mintable token ids map
-    for token_id in token_list {
-        let count = increment_tokens(deps.storage)?;
+    for (i, token_id) in token_list.iter().enumerate() {
+        // i = [0..num_tokens], add 1 to get the expected token key
+        let token_key = i as u32 + 1;
         tokens().save(
             deps.storage,
-            count,
+            token_key,
             &TokenInfo {
-                key: count,
-                id: token_id,
+                key: token_key,
+                id: *token_id,
             },
         )?;
     }

--- a/contracts/minter/src/contract_tests.rs
+++ b/contracts/minter/src/contract_tests.rs
@@ -649,11 +649,22 @@ fn mint_count_query() {
     assert_eq!(res.count, 2);
     assert_eq!(res.address, buyer.to_string());
 
+    let tokens_msg = Cw721QueryMsg::Tokens {
+        owner: buyer.to_string(),
+        start_after: None,
+        limit: None,
+    };
+    let res: TokensResponse = router
+        .wrap()
+        .query_wasm_smart(sg721_addr.clone(), &tokens_msg)
+        .unwrap();
+    let sold_token_id: u32 = res.tokens[0].parse::<u32>().unwrap();
+
     // Buyer transfers NFT to creator
-    // random mint token id: 3
+    // random mint token id: sold_token_id = 7
     let transfer_msg: Cw721ExecuteMsg<Empty> = Cw721ExecuteMsg::TransferNft {
         recipient: creator.to_string(),
-        token_id: "3".to_string(),
+        token_id: sold_token_id.to_string(),
     };
     let res = router.execute_contract(
         buyer.clone(),

--- a/contracts/minter/src/state.rs
+++ b/contracts/minter/src/state.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{Addr, Coin, Timestamp, StdResult, Storage};
+use cosmwasm_std::{Addr, Coin, StdResult, Storage, Timestamp};
 use cw_storage_plus::{Index, IndexList, IndexedMap, Item, Map, UniqueIndex};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -19,7 +19,6 @@ pub struct Config {
 pub const CONFIG: Item<Config> = Item::new("config");
 pub const SG721_ADDRESS: Item<Addr> = Item::new("sg721_address");
 pub const MINTABLE_NUM_TOKENS: Item<u32> = Item::new("mintable_num_tokens");
-
 
 pub fn token_count(storage: &dyn Storage) -> StdResult<u32> {
     Ok(MINTABLE_NUM_TOKENS.may_load(storage)?.unwrap_or_default())
@@ -43,9 +42,9 @@ type TokenKey = u32;
 type TokenId = u32;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct TokenInfo{
+pub struct TokenInfo {
     pub key: TokenKey,
-    pub id: TokenId
+    pub id: TokenId,
 }
 
 pub struct TokenIndices<'a> {

--- a/contracts/minter/src/state.rs
+++ b/contracts/minter/src/state.rs
@@ -24,12 +24,7 @@ pub fn token_count(storage: &dyn Storage) -> StdResult<u32> {
     Ok(MINTABLE_NUM_TOKENS.may_load(storage)?.unwrap_or_default())
 }
 
-pub fn increment_tokens(storage: &mut dyn Storage) -> StdResult<u32> {
-    let val = token_count(storage)? + 1;
-    MINTABLE_NUM_TOKENS.save(storage, &val)?;
-    Ok(val)
-}
-
+// decrements mintable tokens as supply is minted or burned
 pub fn decrement_tokens(storage: &mut dyn Storage) -> StdResult<u32> {
     let val = token_count(storage)? - 1;
     MINTABLE_NUM_TOKENS.save(storage, &val)?;

--- a/contracts/minter/src/state.rs
+++ b/contracts/minter/src/state.rs
@@ -1,8 +1,8 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{Addr, Coin, Timestamp};
-use cw_storage_plus::{Item, Map};
+use cosmwasm_std::{Addr, Coin, Timestamp, StdResult, Storage};
+use cw_storage_plus::{Index, IndexList, IndexedMap, Item, Map, UniqueIndex};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Config {
@@ -18,6 +18,50 @@ pub struct Config {
 
 pub const CONFIG: Item<Config> = Item::new("config");
 pub const SG721_ADDRESS: Item<Addr> = Item::new("sg721_address");
-pub const MINTABLE_TOKEN_IDS: Map<u32, bool> = Map::new("mt");
 pub const MINTABLE_NUM_TOKENS: Item<u32> = Item::new("mintable_num_tokens");
+
+
+pub fn token_count(storage: &dyn Storage) -> StdResult<u32> {
+    Ok(MINTABLE_NUM_TOKENS.may_load(storage)?.unwrap_or_default())
+}
+
+pub fn increment_tokens(storage: &mut dyn Storage) -> StdResult<u32> {
+    let val = token_count(storage)? + 1;
+    MINTABLE_NUM_TOKENS.save(storage, &val)?;
+    Ok(val)
+}
+
+pub fn decrement_tokens(storage: &mut dyn Storage) -> StdResult<u32> {
+    let val = token_count(storage)? - 1;
+    MINTABLE_NUM_TOKENS.save(storage, &val)?;
+    Ok(val)
+}
+
 pub const MINTER_ADDRS: Map<Addr, u32> = Map::new("ma");
+
+type TokenKey = u32;
+type TokenId = u32;
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct TokenInfo{
+    pub key: TokenKey,
+    pub id: TokenId
+}
+
+pub struct TokenIndices<'a> {
+    pub token_ids: UniqueIndex<'a, TokenId, TokenInfo, TokenKey>,
+}
+
+impl<'a> IndexList<TokenInfo> for TokenIndices<'a> {
+    fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<TokenInfo>> + '_> {
+        let v: Vec<&dyn Index<TokenInfo>> = vec![&self.token_ids];
+        Box::new(v.into_iter())
+    }
+}
+
+pub fn tokens<'a>() -> IndexedMap<'a, TokenKey, TokenInfo, TokenIndices<'a>> {
+    let indexes = TokenIndices {
+        token_ids: UniqueIndex::new(|d: &TokenInfo| d.id, "tokens__token_ids"),
+    };
+    IndexedMap::new("tokens", indexes)
+}

--- a/contracts/minter/src/state.rs
+++ b/contracts/minter/src/state.rs
@@ -37,25 +37,25 @@ type TokenKey = u32;
 type TokenId = u32;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct TokenInfo {
+pub struct TokenIndexMapping {
     pub key: TokenKey,
     pub id: TokenId,
 }
 
 pub struct TokenIndices<'a> {
-    pub token_ids: UniqueIndex<'a, TokenId, TokenInfo, TokenKey>,
+    pub token_ids: UniqueIndex<'a, TokenId, TokenIndexMapping, TokenKey>,
 }
 
-impl<'a> IndexList<TokenInfo> for TokenIndices<'a> {
-    fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<TokenInfo>> + '_> {
-        let v: Vec<&dyn Index<TokenInfo>> = vec![&self.token_ids];
+impl<'a> IndexList<TokenIndexMapping> for TokenIndices<'a> {
+    fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<TokenIndexMapping>> + '_> {
+        let v: Vec<&dyn Index<TokenIndexMapping>> = vec![&self.token_ids];
         Box::new(v.into_iter())
     }
 }
 
-pub fn tokens<'a>() -> IndexedMap<'a, TokenKey, TokenInfo, TokenIndices<'a>> {
+pub fn mintable_tokens<'a>() -> IndexedMap<'a, TokenKey, TokenIndexMapping, TokenIndices<'a>> {
     let indexes = TokenIndices {
-        token_ids: UniqueIndex::new(|d: &TokenInfo| d.id, "tokens__token_ids"),
+        token_ids: UniqueIndex::new(|d: &TokenIndexMapping| d.id, "tokens__token_ids"),
     };
     IndexedMap::new("tokens", indexes)
 }


### PR DESCRIPTION
saving the shuffled map doesn't make a difference since it'll be hashed the same way in the merkle tree so querying order will not change. requires using an index. data needs both `token_key` and `token_id`. to both query the presence of `token_id` and know which `token_key` to remove.

jhernandez created multiple small shuffles on the front and back of the list, skipping a pseudo-random number of entries.

please double check token key and token id references are correct.