### PR TITLE
remove unneeded binary export 

### DIFF
--- a/contracts/sg721/examples/schema.rs
+++ b/contracts/sg721/examples/schema.rs
@@ -3,7 +3,7 @@ use std::fs::create_dir_all;
 
 use cosmwasm_schema::{export_schema, export_schema_with_title, remove_schemas, schema_for};
 
-use cosmwasm_std::{Binary, Empty};
+use cosmwasm_std::Empty;
 
 use cw721::{
     AllNftInfoResponse, ApprovalResponse, ApprovalsResponse, ContractInfoResponse, NftInfoResponse,
@@ -21,7 +21,6 @@ fn main() {
     export_schema(&schema_for!(InstantiateMsg), &out_dir);
     export_schema(&schema_for!(ExecuteMsg), &out_dir);
     export_schema(&schema_for!(QueryMsg), &out_dir);
-    export_schema(&schema_for!(Binary), &out_dir);
     export_schema(&schema_for!(CollectionInfoResponse), &out_dir);
     export_schema_with_title(
         &schema_for!(AllNftInfoResponse<Empty>),

--- a/contracts/sg721/schema/binary.json
+++ b/contracts/sg721/schema/binary.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Binary",
-  "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
-  "type": "string"
-}


### PR DESCRIPTION
latest cosmwasm-typescript-gen upgrade fixes an issue that required us to manually export the Binary type. Not necessary anymore, so this configuration is more minimal.