### PR TITLE
randomized token map { position: id }

### DIFF
--- a/contracts/minter/schema/execute_msg.json
+++ b/contracts/minter/schema/execute_msg.json
@@ -117,6 +117,18 @@
     {
       "type": "object",
       "required": [
+        "shuffle"
+      ],
+      "properties": {
+        "shuffle": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
         "withdraw"
       ],
       "properties": {

--- a/contracts/minter/schema/query_msg.json
+++ b/contracts/minter/schema/query_msg.json
@@ -69,6 +69,18 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "mintable_tokens"
+      ],
+      "properties": {
+        "mintable_tokens": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
     }
   ]
 }

--- a/contracts/minter/src/contract.rs
+++ b/contracts/minter/src/contract.rs
@@ -125,12 +125,12 @@ pub fn instantiate(
     CONFIG.save(deps.storage, &config)?;
     MINTABLE_NUM_TOKENS.save(deps.storage, &msg.num_tokens)?;
 
-    let token_positions = random_token_list(&env, (1..=msg.num_tokens).collect::<Vec<u32>>())?;
+    let token_ids = random_token_list(&env, (1..=msg.num_tokens).collect::<Vec<u32>>())?;
     // Save mintable token ids map
-    let mut token_id: u32 = 1;
-    for token_position in token_positions {
+    let mut token_position: u32 = 1;
+    for token_id in token_ids {
         MINTABLE_TOKEN_POSITIONS.save(deps.storage, token_position, &token_id)?;
-        token_id += 1;
+        token_position += 1;
     }
 
     // Submessage to instantiate sg721 contract

--- a/contracts/minter/src/contract.rs
+++ b/contracts/minter/src/contract.rs
@@ -124,12 +124,9 @@ pub fn instantiate(
     CONFIG.save(deps.storage, &config)?;
     MINTABLE_NUM_TOKENS.save(deps.storage, &msg.num_tokens)?;
 
-    let token_list = random_token_list(&env, msg.num_tokens)?;
     // Save mintable token ids map
-    let mut token_position: u32 = 1;
-    for token_id in token_list {
-        MINTABLE_TOKEN_POSITIONS.save(deps.storage, token_position, &token_id)?;
-        token_position += 1;
+    for token_id in 1..=config.num_tokens {
+        MINTABLE_TOKEN_POSITIONS.save(deps.storage, token_id, &token_id)?;
     }
 
     // Submessage to instantiate sg721 contract

--- a/contracts/minter/src/contract.rs
+++ b/contracts/minter/src/contract.rs
@@ -4,7 +4,7 @@ use std::convert::TryInto;
 use crate::error::ContractError;
 use crate::msg::{
     ConfigResponse, ExecuteMsg, InstantiateMsg, MintCountResponse, MintPriceResponse,
-    MintableNumTokensResponse, QueryMsg, StartTimeResponse,
+    MintableNumTokensResponse, MintableTokensResponse, QueryMsg, StartTimeResponse,
 };
 use crate::state::{
     Config, TokenPositionMapping, CONFIG, MINTABLE_NUM_TOKENS, MINTABLE_TOKEN_POSITIONS,
@@ -688,6 +688,8 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::MintableNumTokens {} => to_binary(&query_mintable_num_tokens(deps)?),
         QueryMsg::MintPrice {} => to_binary(&query_mint_price(deps)?),
         QueryMsg::MintCount { address } => to_binary(&query_mint_count(deps, address)?),
+        // TODO for debug to test shuffle. remove before prod
+        QueryMsg::MintableTokens {} => to_binary(&query_mintable_tokens(deps)?),
     }
 }
 
@@ -727,6 +729,19 @@ fn query_start_time(deps: Deps) -> StdResult<StartTimeResponse> {
 fn query_mintable_num_tokens(deps: Deps) -> StdResult<MintableNumTokensResponse> {
     let count = MINTABLE_NUM_TOKENS.load(deps.storage)?;
     Ok(MintableNumTokensResponse { count })
+}
+
+//TODO for debug to test shuffle. remove before prod
+fn query_mintable_tokens(deps: Deps) -> StdResult<MintableTokensResponse> {
+    let tokens = MINTABLE_TOKEN_POSITIONS
+        .range(deps.storage, None, None, Order::Ascending)
+        .into_iter()
+        .map(|t| t.unwrap())
+        .collect::<Vec<_>>();
+
+    Ok(MintableTokensResponse {
+        mintable_tokens: tokens,
+    })
 }
 
 fn query_mint_price(deps: Deps) -> StdResult<MintPriceResponse> {

--- a/contracts/minter/src/contract.rs
+++ b/contracts/minter/src/contract.rs
@@ -506,6 +506,7 @@ fn random_token_list(env: &Env, num_tokens: u32) -> Result<Vec<u32>, ContractErr
     Ok(tokens)
 }
 
+// Does a baby shuffle, picking a token_id from the first or last 50 mintable positions.
 fn random_mintable_token_mapping(
     deps: Deps,
     env: Env,

--- a/contracts/minter/src/contract.rs
+++ b/contracts/minter/src/contract.rs
@@ -206,10 +206,7 @@ pub fn execute_shuffle(
     // get positions and token_ids, then randomize token_ids and reassign positions
     let mut positions: Vec<u32> = Vec::new();
     let mut token_ids: Vec<u32> = Vec::new();
-    for token in MINTABLE_TOKEN_POSITIONS
-        .range(deps.storage, None, None, Order::Ascending)
-        .into_iter()
-    {
+    for token in MINTABLE_TOKEN_POSITIONS.range(deps.storage, None, None, Order::Ascending) {
         positions.push(token.as_ref().unwrap().0);
         token_ids.push(token.as_ref().unwrap().1);
     }

--- a/contracts/minter/src/contract.rs
+++ b/contracts/minter/src/contract.rs
@@ -124,9 +124,12 @@ pub fn instantiate(
     CONFIG.save(deps.storage, &config)?;
     MINTABLE_NUM_TOKENS.save(deps.storage, &msg.num_tokens)?;
 
+    let token_list = random_token_list(&env, msg.num_tokens)?;
     // Save mintable token ids map
-    for token_id in 1..=config.num_tokens {
-        MINTABLE_TOKEN_POSITIONS.save(deps.storage, token_id, &token_id)?;
+    let mut token_position: u32 = 1;
+    for token_id in token_list {
+        MINTABLE_TOKEN_POSITIONS.save(deps.storage, token_position, &token_id)?;
+        token_position += 1;
     }
 
     // Submessage to instantiate sg721 contract

--- a/contracts/minter/src/contract.rs
+++ b/contracts/minter/src/contract.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::convert::TryInto;
 
 use crate::error::ContractError;
@@ -6,7 +7,8 @@ use crate::msg::{
     MintableNumTokensResponse, QueryMsg, StartTimeResponse,
 };
 use crate::state::{
-    Config, CONFIG, MINTABLE_NUM_TOKENS, MINTABLE_TOKEN_IDS, MINTER_ADDRS, SG721_ADDRESS,
+    Config, TokenPositionMapping, CONFIG, MINTABLE_NUM_TOKENS, MINTABLE_TOKEN_POSITIONS,
+    MINTER_ADDRS, SG721_ADDRESS,
 };
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
@@ -124,8 +126,10 @@ pub fn instantiate(
 
     let token_list = random_token_list(&env, msg.num_tokens)?;
     // Save mintable token ids map
+    let mut token_position: u32 = 1;
     for token_id in token_list {
-        MINTABLE_TOKEN_IDS.save(deps.storage, token_id, &true)?;
+        MINTABLE_TOKEN_POSITIONS.save(deps.storage, token_position, &token_id)?;
+        token_position += 1;
     }
 
     // Submessage to instantiate sg721 contract
@@ -373,11 +377,8 @@ fn _execute_mint(
     recipient: Option<Addr>,
     token_id: Option<u32>,
 ) -> Result<Response, ContractError> {
-    let mintable = MINTABLE_TOKEN_IDS
-        .keys(deps.storage, None, None, Order::Ascending)
-        .next()
-        .is_some();
-    if !mintable {
+    let mintable: MintableNumTokensResponse = query_mintable_num_tokens(deps.as_ref())?;
+    if mintable.count == 0 {
         return Err(ContractError::SoldOut {});
     }
 
@@ -411,28 +412,59 @@ fn _execute_mint(
         network_fee
     };
 
-    let mintable_token_id = match token_id {
+    let mintable_token_positions: Vec<u32> = MINTABLE_TOKEN_POSITIONS
+        .keys(deps.storage, None, None, Order::Ascending)
+        .map(|x| x.unwrap())
+        .collect();
+    let mintable_token_mapping: TokenPositionMapping = match token_id {
         Some(token_id) => {
             if token_id == 0 || token_id > config.num_tokens {
                 return Err(ContractError::InvalidTokenId {});
             }
-            // If token_id not on mintable map, throw err
-            if !MINTABLE_TOKEN_IDS.has(deps.storage, token_id) {
-                return Err(ContractError::TokenIdAlreadySold { token_id });
+
+            // iterate map of token positions
+            // check if MINTABLE_TOKEN_POSITIONS value is token_id
+            let position = mintable_token_positions
+                .iter()
+                .filter_map(|position| {
+                    let result = MINTABLE_TOKEN_POSITIONS
+                        .load(deps.storage, *position)
+                        .unwrap()
+                        .cmp(&token_id);
+                    match result {
+                        Ordering::Equal => Some(*position),
+                        _ => None,
+                    }
+                })
+                .collect::<Vec<_>>();
+
+            match position.first() {
+                // If token_id exists, ready to mint
+                Some(position) => TokenPositionMapping {
+                    position: *position,
+                    token_id,
+                },
+                // If token_id not contained in mintable_token_ids, throw err
+                None => {
+                    return Err(ContractError::TokenIdAlreadySold { token_id });
+                }
             }
-            token_id
         }
         None => {
-            let token_id: u32 = random_mintable_token_id(deps.as_ref(), env, info.sender.clone())?;
-            token_id
+            let token_mapping: TokenPositionMapping =
+                random_mintable_token_mapping(deps.as_ref(), env, info.sender.clone())?;
+            token_mapping
         }
     };
 
     // Create mint msgs
     let mint_msg = Cw721ExecuteMsg::Mint(MintMsg::<Empty> {
-        token_id: mintable_token_id.to_string(),
+        token_id: mintable_token_mapping.token_id.to_string(),
         owner: recipient_addr.to_string(),
-        token_uri: Some(format!("{}/{}", config.base_token_uri, mintable_token_id)),
+        token_uri: Some(format!(
+            "{}/{}",
+            config.base_token_uri, mintable_token_mapping.token_id
+        )),
         extension: Empty {},
     });
     let msg = CosmosMsg::Wasm(WasmMsg::Execute {
@@ -442,8 +474,8 @@ fn _execute_mint(
     });
     msgs.append(&mut vec![msg]);
 
-    // Remove mintable token id from map
-    MINTABLE_TOKEN_IDS.remove(deps.storage, mintable_token_id);
+    // Remove mintable token position from map
+    MINTABLE_TOKEN_POSITIONS.remove(deps.storage, mintable_token_mapping.position);
     let mintable_num_tokens = MINTABLE_NUM_TOKENS.load(deps.storage)?;
     // Decrement mintable num tokens
     MINTABLE_NUM_TOKENS.save(deps.storage, &(mintable_num_tokens - 1))?;
@@ -455,7 +487,7 @@ fn _execute_mint(
         .add_attribute("action", action)
         .add_attribute("sender", info.sender)
         .add_attribute("recipient", recipient_addr)
-        .add_attribute("token_id", mintable_token_id.to_string())
+        .add_attribute("token_id", mintable_token_mapping.token_id.to_string())
         .add_attribute("network_fee", network_fee)
         .add_attribute("mint_price", mint_price.amount)
         .add_messages(msgs))
@@ -474,7 +506,11 @@ fn random_token_list(env: &Env, num_tokens: u32) -> Result<Vec<u32>, ContractErr
     Ok(tokens)
 }
 
-fn random_mintable_token_id(deps: Deps, env: Env, sender: Addr) -> Result<u32, ContractError> {
+fn random_mintable_token_mapping(
+    deps: Deps,
+    env: Env,
+    sender: Addr,
+) -> Result<TokenPositionMapping, ContractError> {
     let num_tokens = MINTABLE_NUM_TOKENS.load(deps.storage)?;
     let sha256 =
         Sha256::digest(format!("{}{}{}", sender, num_tokens, env.block.height).into_bytes());
@@ -494,12 +530,14 @@ fn random_mintable_token_id(deps: Deps, env: Env, sender: Addr) -> Result<u32, C
         rem = num_tokens;
     }
     let n = r % rem;
-    let mintable_tokens = MINTABLE_TOKEN_IDS
+    let position = MINTABLE_TOKEN_POSITIONS
         .keys(deps.storage, None, None, order)
         .skip(n as usize)
         .take(1)
-        .collect::<StdResult<Vec<_>>>()?;
-    Ok(mintable_tokens[0])
+        .collect::<StdResult<Vec<_>>>()?[0];
+
+    let token_id: u32 = MINTABLE_TOKEN_POSITIONS.load(deps.storage, position)?;
+    Ok(TokenPositionMapping { position, token_id })
 }
 
 pub fn execute_update_start_time(

--- a/contracts/minter/src/contract_tests.rs
+++ b/contracts/minter/src/contract_tests.rs
@@ -649,11 +649,24 @@ fn mint_count_query() {
     assert_eq!(res.count, 2);
     assert_eq!(res.address, buyer.to_string());
 
+    // get random mint token_id
+    let tokens_msg = Cw721QueryMsg::Tokens {
+        owner: buyer.to_string(),
+        start_after: None,
+        limit: None,
+    };
+    let res: TokensResponse = router
+        .wrap()
+        .query_wasm_smart(sg721_addr.clone(), &tokens_msg)
+        .unwrap();
+    let sold_token_id: u32 = res.tokens[1].parse::<u32>().unwrap();
+    println!("sold token id: {}", sold_token_id);
+
     // Buyer transfers NFT to creator
-    // random mint token id: 7
+    // random mint token id: 9
     let transfer_msg: Cw721ExecuteMsg<Empty> = Cw721ExecuteMsg::TransferNft {
         recipient: creator.to_string(),
-        token_id: "7".to_string(),
+        token_id: "9".to_string(),
     };
     let res = router.execute_contract(
         buyer.clone(),

--- a/contracts/minter/src/contract_tests.rs
+++ b/contracts/minter/src/contract_tests.rs
@@ -650,10 +650,10 @@ fn mint_count_query() {
     assert_eq!(res.address, buyer.to_string());
 
     // Buyer transfers NFT to creator
-    // random mint token id: 3
+    // random mint token id: 7
     let transfer_msg: Cw721ExecuteMsg<Empty> = Cw721ExecuteMsg::TransferNft {
         recipient: creator.to_string(),
-        token_id: "3".to_string(),
+        token_id: "7".to_string(),
     };
     let res = router.execute_contract(
         buyer.clone(),

--- a/contracts/minter/src/contract_tests.rs
+++ b/contracts/minter/src/contract_tests.rs
@@ -1130,7 +1130,7 @@ fn mint_for_token_id_addr() {
     };
     let res: TokensResponse = router
         .wrap()
-        .query_wasm_smart(config.sg721_address, &tokens_msg)
+        .query_wasm_smart(config.sg721_address.clone(), &tokens_msg)
         .unwrap();
     let sold_token_id: u32 = res.tokens[0].parse::<u32>().unwrap();
 
@@ -1210,6 +1210,18 @@ fn mint_for_token_id_addr() {
         }),
     );
     assert!(res.is_ok());
+
+    let res: OwnerOfResponse = router
+        .wrap()
+        .query_wasm_smart(
+            config.sg721_address,
+            &Cw721QueryMsg::OwnerOf {
+                token_id: 2.to_string(),
+                include_expired: None,
+            },
+        )
+        .unwrap();
+    assert_eq!(res.owner.to_string(), buyer.to_string());
 
     let mintable_num_tokens_response: MintableNumTokensResponse = router
         .wrap()

--- a/contracts/minter/src/contract_tests.rs
+++ b/contracts/minter/src/contract_tests.rs
@@ -1546,7 +1546,7 @@ fn shuffle() {
         .wrap()
         .query_wasm_smart(minter_addr.clone(), &query_mintable_tokens_msg)
         .unwrap();
-    dbg!("{:?}", res);
+    dbg!("after initialize {:?}", res);
     // perform shuffle
     let shuffle_msg = ExecuteMsg::Shuffle {};
     let funds = coins(SHUFFLE_FEE, NATIVE_DENOM);
@@ -1558,7 +1558,7 @@ fn shuffle() {
         .wrap()
         .query_wasm_smart(minter_addr.clone(), &query_mintable_tokens_msg)
         .unwrap();
-    println!("{:?}", res);
+    dbg!("after shuffle {:?}", res);
     // mint a few tokens
     let mut i = 0;
     while i < 3 {
@@ -1584,7 +1584,7 @@ fn shuffle() {
         .wrap()
         .query_wasm_smart(minter_addr.clone(), &query_mintable_tokens_msg)
         .unwrap();
-    println!("{:?}", res);
+    dbg!("{:?}", res);
     // perform shuffle
     let shuffle_msg = ExecuteMsg::Shuffle {};
     let funds = coins(SHUFFLE_FEE, NATIVE_DENOM);
@@ -1596,7 +1596,7 @@ fn shuffle() {
         .wrap()
         .query_wasm_smart(minter_addr.clone(), &query_mintable_tokens_msg)
         .unwrap();
-    println!("{:?}", res);
+    dbg!("after another shuffle {:?}", res);
     // mint until sold out
     while i < num_tokens {
         let mint_to_msg = ExecuteMsg::MintTo {

--- a/contracts/minter/src/contract_tests.rs
+++ b/contracts/minter/src/contract_tests.rs
@@ -663,10 +663,10 @@ fn mint_count_query() {
     println!("sold token id: {}", sold_token_id);
 
     // Buyer transfers NFT to creator
-    // random mint token id: 9
+    // random mint token id: 8
     let transfer_msg: Cw721ExecuteMsg<Empty> = Cw721ExecuteMsg::TransferNft {
         recipient: creator.to_string(),
-        token_id: "9".to_string(),
+        token_id: "8".to_string(),
     };
     let res = router.execute_contract(
         buyer.clone(),

--- a/contracts/minter/src/contract_tests.rs
+++ b/contracts/minter/src/contract_tests.rs
@@ -1221,7 +1221,7 @@ fn mint_for_token_id_addr() {
             },
         )
         .unwrap();
-    assert_eq!(res.owner.to_string(), buyer.to_string());
+    assert_eq!(res.owner, buyer.to_string());
 
     let mintable_num_tokens_response: MintableNumTokensResponse = router
         .wrap()

--- a/contracts/minter/src/msg.rs
+++ b/contracts/minter/src/msg.rs
@@ -37,6 +37,7 @@ pub enum QueryMsg {
     StartTime {},
     MintPrice {},
     MintCount { address: String },
+    MintableTokens {},
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -73,4 +74,10 @@ pub struct MintPriceResponse {
 pub struct MintCountResponse {
     pub address: String,
     pub count: u32,
+}
+
+//TODO for debug to test shuffle. remove before prod
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct MintableTokensResponse {
+    pub mintable_tokens: Vec<(u32, u32)>,
 }

--- a/contracts/minter/src/msg.rs
+++ b/contracts/minter/src/msg.rs
@@ -25,6 +25,7 @@ pub enum ExecuteMsg {
     UpdatePerAddressLimit { per_address_limit: u32 },
     MintTo { recipient: String },
     MintFor { token_id: u32, recipient: String },
+    Shuffle {},
     Withdraw {},
 }
 

--- a/contracts/minter/src/state.rs
+++ b/contracts/minter/src/state.rs
@@ -18,6 +18,13 @@ pub struct Config {
 
 pub const CONFIG: Item<Config> = Item::new("config");
 pub const SG721_ADDRESS: Item<Addr> = Item::new("sg721_address");
-pub const MINTABLE_TOKEN_IDS: Map<u32, bool> = Map::new("mt");
+// map of index position and token id
+pub const MINTABLE_TOKEN_POSITIONS: Map<u32, u32> = Map::new("mt");
 pub const MINTABLE_NUM_TOKENS: Item<u32> = Item::new("mintable_num_tokens");
 pub const MINTER_ADDRS: Map<Addr, u32> = Map::new("ma");
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct TokenPositionMapping {
+    pub position: u32,
+    pub token_id: u32,
+}

--- a/packages/sg-utils/src/bech32_convert.rs
+++ b/packages/sg-utils/src/bech32_convert.rs
@@ -23,7 +23,7 @@ impl ToStars for str {
 
 impl ToStars for Addr {
     fn to_stars(&self) -> Result<String, Error> {
-        let decoded = decode_and_convert(&self.to_string())?;
+        let decoded = decode_and_convert(self.as_ref())?;
         convert_and_encode(PREFIX.to_string(), decoded.1)
     }
 }


### PR DESCRIPTION
**DO NOT MERGE YET** need to remove the mintable tokens query before merging

saving the shuffled map doesn't make a difference since it'll be hashed the same way in the merkle tree so querying order will not change. requires using an index. data needs both `token_key` and `token_id`. to both query the presence of `token_id` and know which `token_key` to remove.

jhernandez created multiple small shuffles on the front and back of the list, skipping a pseudo-random number of entries.

this is the v0.1 PR resulting from a series of tests
- switch tokens to multi map
- switch tokens to array
- benchmark against existing token instantiation
- move validation to the front of function blocks

we settled on this version because it adds cost efficient randomization and a few additional enhancements.

still need to test a few things on testnet:
- try minter instantiate look at tx for gas
- try random minting and look at tx's for gas
- try shuffle and look at tx's for gas
- try random minting and look at tx's for gas
- try mint_for multiple times and inspect token ids
- try mint_to multiple times and inspect token ids

```
TESTNET CODE_ID: 91
minter: stars15gdrt02y3x6juldarcu2rt6y6l8gklaneh446uj2yrcsa7myamtqj5zlgf
sg721:  stars175evjsxpxf5347an078zmk3gzjy7df6kjml0mfwxvzpuu5jps8gsx3caxe
batch mint 20 tokens takes 37M gas https://stargaze-testnet-explorer.pages.dev/stargaze/tx/A72BAD4520B2E23DEE2844B4A735FC33931588A86C414EF200A978DEC05A6F8F
```
