### PR TITLE
Use sg721-base rather than cw721-base

### DIFF
--- a/contracts/sg721-base/src/lib.rs
+++ b/contracts/sg721-base/src/lib.rs
@@ -7,7 +7,7 @@ pub mod integration_tests;
 pub mod msg;
 pub mod state;
 pub use crate::error::ContractError;
-use cw721_base::Extension;
+pub use cw721_base::Extension;
 use sg721::InstantiateMsg;
 use sg_std::StargazeMsgWrapper;
 

--- a/contracts/sg721-nt/Cargo.toml
+++ b/contracts/sg721-nt/Cargo.toml
@@ -36,8 +36,8 @@ serde = { version = "1.0.133", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.30" }
 sg-std = { path = "../../packages/sg-std" }
 url = "2.2.2"
-cw721 = "0.13.2"
-cw721-base = { version = "0.13.2", features = ["library"] }
+cw721 = "0.13.4"
+cw721-base = { version = "0.13.4", features = ["library"] }
 sg721 = { path = "../../packages/sg721" }
 sg721-base = { path = "../sg721-base", features = ["library"] }
 

--- a/contracts/sg721-nt/src/contract.rs
+++ b/contracts/sg721-nt/src/contract.rs
@@ -6,14 +6,14 @@ use cw2::set_contract_version;
 use sg721::InstantiateMsg;
 use sg_std::Response;
 
-use crate::Cw721Base;
+use crate::Sg721Base;
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:sg721-nt";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn _instantiate(
-    contract: Cw721Base,
+    contract: Sg721Base,
     deps: DepsMut,
     _env: Env,
     info: MessageInfo,

--- a/contracts/sg721-nt/src/lib.rs
+++ b/contracts/sg721-nt/src/lib.rs
@@ -14,8 +14,8 @@ pub mod entry {
         contract::_instantiate,
         msg::{ExecuteMsg, QueryMsg},
     };
-    use cosmwasm_std::{to_binary, Binary, Deps, DepsMut, Env, MessageInfo, StdResult};
-    use sg721_base::contract::{burn, mint, query_collection_info, ready};
+    use cosmwasm_std::{Binary, Deps, DepsMut, Env, MessageInfo, StdResult};
+    use sg721_base::contract::{burn, mint, ready};
     use sg_std::Response;
 
     #[cfg_attr(not(feature = "library"), entry_point)]
@@ -46,9 +46,6 @@ pub mod entry {
 
     #[cfg_attr(not(feature = "library"), entry_point)]
     pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
-        match msg {
-            QueryMsg::CollectionInfo {} => to_binary(&query_collection_info(deps)?),
-            _ => Sg721Base::default().query(deps, env, msg.into()),
-        }
+        Sg721Base::default().query(deps, env, msg.into())
     }
 }

--- a/contracts/sg721-nt/src/lib.rs
+++ b/contracts/sg721-nt/src/lib.rs
@@ -3,11 +3,10 @@ use cosmwasm_std::entry_point;
 
 pub mod contract;
 pub mod msg;
-use cw721_base::Extension;
 use sg721::InstantiateMsg;
-use sg_std::StargazeMsgWrapper;
+pub use sg721_base::Extension;
 
-pub type Cw721Base<'a> = cw721_base::Cw721Contract<'a, Extension, StargazeMsgWrapper>;
+pub type Sg721Base<'a> = sg721_base::Cw721Base<'a>;
 
 pub mod entry {
     use super::*;
@@ -26,7 +25,7 @@ pub mod entry {
         info: MessageInfo,
         msg: InstantiateMsg,
     ) -> Result<Response, sg721_base::ContractError> {
-        let tract = Cw721Base::default();
+        let tract = Sg721Base::default();
         _instantiate(tract, deps, env, info, msg)
     }
 
@@ -37,7 +36,7 @@ pub mod entry {
         info: MessageInfo,
         msg: ExecuteMsg<Extension>,
     ) -> Result<Response, sg721_base::ContractError> {
-        let tract = Cw721Base::default();
+        let tract = Sg721Base::default();
         match msg {
             ExecuteMsg::_Ready {} => ready(tract, deps, env, info),
             ExecuteMsg::Burn { token_id } => burn(tract, deps, env, info, token_id),
@@ -49,7 +48,7 @@ pub mod entry {
     pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
         match msg {
             QueryMsg::CollectionInfo {} => to_binary(&query_collection_info(deps)?),
-            _ => Cw721Base::default().query(deps, env, msg.into()),
+            _ => Sg721Base::default().query(deps, env, msg.into()),
         }
     }
 }


### PR DESCRIPTION
@yubrew

Here's an example of how to use `sg721-base` with `sg721-nt`. It's a little confusing since we're extending an extension... may inform some refactoring.