### PR TITLE
refactor `sg721-base`, add `sg721-metadata-onchain` contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,6 +855,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "sg-metadata"
+version = "0.14.0"
+dependencies = [
+ "schemars",
+ "serde",
+]
+
+[[package]]
 name = "sg-multi-test"
 version = "0.15.1"
 dependencies = [
@@ -1104,7 +1112,7 @@ dependencies = [
 
 [[package]]
 name = "sg721-base"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1122,6 +1130,31 @@ dependencies = [
  "sg721 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "url",
+ "vending-factory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vending-minter 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sg721-metadata-onchain"
+version = "0.14.0"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-multi-test",
+ "cw-storage-plus",
+ "cw-utils",
+ "cw2",
+ "cw721",
+ "cw721-base",
+ "schemars",
+ "serde",
+ "sg-metadata",
+ "sg-multi-test 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sg-std 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sg2 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sg721 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sg721-base 0.14.0",
+ "thiserror",
  "vending-factory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vending-minter 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,23 +1140,15 @@ version = "0.14.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-multi-test",
- "cw-storage-plus",
- "cw-utils",
  "cw2",
  "cw721",
  "cw721-base",
  "schemars",
  "serde",
  "sg-metadata",
- "sg-multi-test 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sg-std 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sg2 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sg721 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sg721-base 0.14.0",
- "thiserror",
- "vending-factory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vending-minter 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/contracts/sg721-base/src/contract.rs
+++ b/contracts/sg721-base/src/contract.rs
@@ -1,351 +1,390 @@
 use cw721_base::state::TokenInfo;
-use cw721_base::Extension;
 use url::Url;
 
-use cosmwasm_std::{Binary, Decimal, Deps, DepsMut, Env, Event, MessageInfo, StdResult};
-use cw2::set_contract_version;
+use cosmwasm_std::{to_binary, Binary, Decimal, Deps, DepsMut, Env, Event, MessageInfo, StdResult};
+
 use cw721::{ContractInfoResponse, Cw721ReceiveMsg};
 use cw_utils::{nonpayable, Expiration};
+use serde::{de::DeserializeOwned, Serialize};
 
-use sg721::{CollectionInfo, InstantiateMsg, MintMsg, RoyaltyInfo, RoyaltyInfoResponse};
+use sg721::{
+    CollectionInfo, ExecuteMsg, InstantiateMsg, MintMsg, RoyaltyInfo, RoyaltyInfoResponse,
+};
 use sg_std::Response;
 
-use crate::msg::CollectionInfoResponse;
-use crate::state::{COLLECTION_INFO, READY};
-use crate::{ContractError, Cw721Base};
-
-// version info for migration info
-const CONTRACT_NAME: &str = "crates.io:sg721-base";
-const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+use crate::msg::{CollectionInfoResponse, QueryMsg};
+use crate::{ContractError, Sg721Contract};
 
 const MAX_DESCRIPTION_LENGTH: u32 = 512;
 
-pub fn _instantiate(
-    contract: Cw721Base,
-    deps: DepsMut,
-    _env: Env,
-    info: MessageInfo,
-    msg: InstantiateMsg,
-) -> Result<Response, ContractError> {
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+impl<'a, T> Sg721Contract<'a, T>
+where
+    T: Serialize + DeserializeOwned + Clone,
+{
+    pub fn instantiate(
+        &self,
+        deps: DepsMut,
+        _env: Env,
+        info: MessageInfo,
+        msg: InstantiateMsg,
+    ) -> Result<Response, ContractError>
+    where
+        T: Serialize + DeserializeOwned + Clone,
+    {
+        // no funds should be sent to this contract
+        nonpayable(&info)?;
 
-    create(contract, deps, info, msg)
-}
+        // cw721 instantiation
+        let info = ContractInfoResponse {
+            name: msg.name,
+            symbol: msg.symbol,
+        };
+        self.parent.contract_info.save(deps.storage, &info)?;
 
-pub fn create(
-    contract: Cw721Base,
-    deps: DepsMut,
-    info: MessageInfo,
-    msg: InstantiateMsg,
-) -> Result<Response, ContractError> {
-    // no funds should be sent to this contract
-    nonpayable(&info)?;
+        let minter = deps.api.addr_validate(&msg.minter)?;
+        self.parent.minter.save(deps.storage, &minter)?;
 
-    // cw721 instantiation
-    let info = ContractInfoResponse {
-        name: msg.name,
-        symbol: msg.symbol,
-    };
-    contract.contract_info.save(deps.storage, &info)?;
+        // sg721 instantiation
+        if msg.collection_info.description.len() > MAX_DESCRIPTION_LENGTH as usize {
+            return Err(ContractError::DescriptionTooLong {});
+        }
 
-    let minter = deps.api.addr_validate(&msg.minter)?;
-    contract.minter.save(deps.storage, &minter)?;
+        let image = Url::parse(&msg.collection_info.image)?;
 
-    // sg721 instantiation
-    if msg.collection_info.description.len() > MAX_DESCRIPTION_LENGTH as usize {
-        return Err(ContractError::DescriptionTooLong {});
+        if let Some(ref external_link) = msg.collection_info.external_link {
+            Url::parse(external_link)?;
+        }
+
+        let royalty_info: Option<RoyaltyInfo> = match msg.collection_info.royalty_info {
+            Some(royalty_info) => Some(RoyaltyInfo {
+                payment_address: deps.api.addr_validate(&royalty_info.payment_address)?,
+                share: share_validate(royalty_info.share)?,
+            }),
+            None => None,
+        };
+
+        deps.api.addr_validate(&msg.collection_info.creator)?;
+
+        let collection_info = CollectionInfo {
+            creator: msg.collection_info.creator,
+            description: msg.collection_info.description,
+            image: msg.collection_info.image,
+            external_link: msg.collection_info.external_link,
+            royalty_info,
+        };
+
+        self.collection_info.save(deps.storage, &collection_info)?;
+
+        self.ready.save(deps.storage, &false)?;
+
+        Ok(Response::new()
+            .add_attribute("action", "instantiate")
+            .add_attribute("collection_name", info.name)
+            .add_attribute("image", image.to_string()))
     }
 
-    let image = Url::parse(&msg.collection_info.image)?;
-
-    if let Some(ref external_link) = msg.collection_info.external_link {
-        Url::parse(external_link)?;
+    pub fn execute(
+        &self,
+        deps: DepsMut,
+        env: Env,
+        info: MessageInfo,
+        msg: ExecuteMsg<T>,
+    ) -> Result<Response, ContractError> {
+        match msg {
+            ExecuteMsg::_Ready {} => self.ready(deps, env, info),
+            ExecuteMsg::TransferNft {
+                recipient,
+                token_id,
+            } => self.transfer_nft(deps, env, info, recipient, token_id),
+            ExecuteMsg::SendNft {
+                contract,
+                token_id,
+                msg,
+            } => self.send_nft(deps, env, info, contract, token_id, msg),
+            ExecuteMsg::Approve {
+                spender,
+                token_id,
+                expires,
+            } => self.approve(deps, env, info, spender, token_id, expires),
+            ExecuteMsg::Revoke { spender, token_id } => {
+                self.revoke(deps, env, info, spender, token_id)
+            }
+            ExecuteMsg::ApproveAll { operator, expires } => {
+                self.approve_all(deps, env, info, operator, expires)
+            }
+            ExecuteMsg::RevokeAll { operator } => self.revoke_all(deps, env, info, operator),
+            ExecuteMsg::Burn { token_id } => self.burn(deps, env, info, token_id),
+            ExecuteMsg::Mint(msg) => self.mint(deps, env, info, msg),
+        }
     }
 
-    let royalty_info: Option<RoyaltyInfo> = match msg.collection_info.royalty_info {
-        Some(royalty_info) => Some(RoyaltyInfo {
-            payment_address: deps.api.addr_validate(&royalty_info.payment_address)?,
-            share: share_validate(royalty_info.share)?,
-        }),
-        None => None,
-    };
+    /// Called by the minter reply handler after instantiation. Now we can query
+    /// the factory and minter to verify that the collection creation is authorized.
+    pub fn ready(
+        &self,
+        deps: DepsMut,
+        _env: Env,
+        info: MessageInfo,
+    ) -> Result<Response, ContractError> {
+        let minter = self.parent.minter.load(deps.storage)?;
+        if minter != info.sender {
+            return Err(ContractError::Unauthorized {});
+        }
 
-    deps.api.addr_validate(&msg.collection_info.creator)?;
+        self.ready.save(deps.storage, &true)?;
 
-    let collection_info = CollectionInfo {
-        creator: msg.collection_info.creator,
-        description: msg.collection_info.description,
-        image: msg.collection_info.image,
-        external_link: msg.collection_info.external_link,
-        royalty_info,
-    };
-
-    COLLECTION_INFO.save(deps.storage, &collection_info)?;
-
-    READY.save(deps.storage, &false)?;
-
-    Ok(Response::new()
-        .add_attribute("action", "instantiate")
-        .add_attribute("contract_name", CONTRACT_NAME)
-        .add_attribute("contract_version", CONTRACT_VERSION)
-        .add_attribute("collection_name", info.name)
-        .add_attribute("image", image.to_string()))
-}
-
-/// Called by the minter reply handler after instantiation. Now we can query
-/// the factory and minter to verify that the collection creation is authorized.
-pub fn ready(
-    _contract: Cw721Base,
-    deps: DepsMut,
-    _env: Env,
-    info: MessageInfo,
-) -> Result<Response, ContractError> {
-    let minter = Cw721Base::default().minter.load(deps.storage)?;
-    if minter != info.sender {
-        return Err(ContractError::Unauthorized {});
+        Ok(Response::new())
     }
 
-    READY.save(deps.storage, &true)?;
+    pub fn approve(
+        &self,
+        deps: DepsMut,
+        env: Env,
+        info: MessageInfo,
+        spender: String,
+        token_id: String,
+        expires: Option<Expiration>,
+    ) -> Result<Response, ContractError> {
+        if !self.ready.load(deps.storage)? {
+            return Err(ContractError::NotReady {});
+        }
 
-    Ok(Response::new())
-}
+        self.parent
+            ._update_approvals(deps, &env, &info, &spender, &token_id, true, expires)?;
 
-pub fn approve(
-    contract: Cw721Base,
-    deps: DepsMut,
-    env: Env,
-    info: MessageInfo,
-    spender: String,
-    token_id: String,
-    expires: Option<Expiration>,
-) -> Result<Response, ContractError> {
-    if !READY.load(deps.storage)? {
-        return Err(ContractError::NotReady {});
+        let event = Event::new("approve")
+            .add_attribute("sender", info.sender)
+            .add_attribute("spender", spender)
+            .add_attribute("token_id", token_id);
+        let res = Response::new().add_event(event);
+
+        Ok(res)
     }
 
-    contract._update_approvals(deps, &env, &info, &spender, &token_id, true, expires)?;
+    pub fn approve_all(
+        &self,
+        deps: DepsMut,
+        env: Env,
+        info: MessageInfo,
+        operator: String,
+        expires: Option<Expiration>,
+    ) -> Result<Response, ContractError> {
+        if !self.ready.load(deps.storage)? {
+            return Err(ContractError::NotReady {});
+        }
+        // reject expired data as invalid
+        let expires = expires.unwrap_or_default();
+        if expires.is_expired(&env.block) {
+            return Err(ContractError::Expired {});
+        }
 
-    let event = Event::new("approve")
-        .add_attribute("sender", info.sender)
-        .add_attribute("spender", spender)
-        .add_attribute("token_id", token_id);
-    let res = Response::new().add_event(event);
+        // set the operator for us
+        let operator_addr = deps.api.addr_validate(&operator)?;
+        self.parent
+            .operators
+            .save(deps.storage, (&info.sender, &operator_addr), &expires)?;
 
-    Ok(res)
-}
+        let event = Event::new("approve_all")
+            .add_attribute("sender", info.sender)
+            .add_attribute("operator", operator);
+        let res = Response::new().add_event(event);
 
-pub fn approve_all(
-    contract: Cw721Base,
-    deps: DepsMut,
-    env: Env,
-    info: MessageInfo,
-    operator: String,
-    expires: Option<Expiration>,
-) -> Result<Response, ContractError> {
-    if !READY.load(deps.storage)? {
-        return Err(ContractError::NotReady {});
-    }
-    // reject expired data as invalid
-    let expires = expires.unwrap_or_default();
-    if expires.is_expired(&env.block) {
-        return Err(ContractError::Expired {});
-    }
-
-    // set the operator for us
-    let operator_addr = deps.api.addr_validate(&operator)?;
-    contract
-        .operators
-        .save(deps.storage, (&info.sender, &operator_addr), &expires)?;
-
-    let event = Event::new("approve_all")
-        .add_attribute("sender", info.sender)
-        .add_attribute("operator", operator);
-    let res = Response::new().add_event(event);
-
-    Ok(res)
-}
-
-pub fn burn(
-    contract: Cw721Base,
-    deps: DepsMut,
-    env: Env,
-    info: MessageInfo,
-    token_id: String,
-) -> Result<Response, ContractError> {
-    if !READY.load(deps.storage)? {
-        return Err(ContractError::NotReady {});
-    }
-    let token = contract.tokens.load(deps.storage, &token_id)?;
-    contract.check_can_send(deps.as_ref(), &env, &info, &token)?;
-
-    contract.tokens.remove(deps.storage, &token_id)?;
-    contract.decrement_tokens(deps.storage)?;
-
-    let event = Event::new("burn")
-        .add_attribute("sender", info.sender)
-        .add_attribute("token_id", token_id);
-    let res = Response::new().add_event(event);
-
-    Ok(res)
-}
-
-pub fn revoke(
-    contract: Cw721Base,
-    deps: DepsMut,
-    env: Env,
-    info: MessageInfo,
-    spender: String,
-    token_id: String,
-) -> Result<Response, ContractError> {
-    if !READY.load(deps.storage)? {
-        return Err(ContractError::NotReady {});
-    }
-    contract._update_approvals(deps, &env, &info, &spender, &token_id, false, None)?;
-
-    let event = Event::new("revoke")
-        .add_attribute("sender", info.sender)
-        .add_attribute("spender", spender)
-        .add_attribute("token_id", token_id);
-    let res = Response::new().add_event(event);
-
-    Ok(res)
-}
-
-pub fn revoke_all(
-    contract: Cw721Base,
-    deps: DepsMut,
-    _env: Env,
-    info: MessageInfo,
-    operator: String,
-) -> Result<Response, ContractError> {
-    if !READY.load(deps.storage)? {
-        return Err(ContractError::NotReady {});
-    }
-    let operator_addr = deps.api.addr_validate(&operator)?;
-    contract
-        .operators
-        .remove(deps.storage, (&info.sender, &operator_addr));
-
-    let event = Event::new("revoke_all")
-        .add_attribute("sender", info.sender)
-        .add_attribute("operator", operator);
-    let res = Response::new().add_event(event);
-
-    Ok(res)
-}
-
-pub fn send_nft(
-    contract: Cw721Base,
-    deps: DepsMut,
-    env: Env,
-    info: MessageInfo,
-    receiving_contract: String,
-    token_id: String,
-    msg: Binary,
-) -> Result<Response, ContractError> {
-    if !READY.load(deps.storage)? {
-        return Err(ContractError::NotReady {});
-    }
-    // Transfer token
-    contract._transfer_nft(deps, &env, &info, &receiving_contract, &token_id)?;
-
-    let send = Cw721ReceiveMsg {
-        sender: info.sender.to_string(),
-        token_id: token_id.clone(),
-        msg,
-    };
-
-    // Send message
-    let event = Event::new("send_nft")
-        .add_attribute("sender", info.sender)
-        .add_attribute("recipient", receiving_contract.to_string())
-        .add_attribute("token_id", token_id);
-    let res = Response::new()
-        .add_message(send.into_cosmos_msg(receiving_contract)?)
-        .add_event(event);
-
-    Ok(res)
-}
-
-pub fn transfer_nft(
-    contract: Cw721Base,
-    deps: DepsMut,
-    env: Env,
-    info: MessageInfo,
-    recipient: String,
-    token_id: String,
-) -> Result<Response, ContractError> {
-    if !READY.load(deps.storage)? {
-        return Err(ContractError::NotReady {});
-    }
-    contract._transfer_nft(deps, &env, &info, &recipient, &token_id)?;
-
-    let event = Event::new("transfer_nft")
-        .add_attribute("sender", info.sender)
-        .add_attribute("recipient", recipient)
-        .add_attribute("token_id", token_id);
-    let res = Response::new().add_event(event);
-
-    Ok(res)
-}
-
-pub fn mint(
-    contract: Cw721Base,
-    deps: DepsMut,
-    _env: Env,
-    info: MessageInfo,
-    msg: MintMsg<Extension>,
-) -> Result<Response, ContractError> {
-    if !READY.load(deps.storage)? {
-        return Err(ContractError::NotReady {});
-    }
-    let minter = contract.minter.load(deps.storage)?;
-
-    if info.sender != minter {
-        return Err(ContractError::Unauthorized {});
+        Ok(res)
     }
 
-    // create the token
-    let token = TokenInfo {
-        owner: deps.api.addr_validate(&msg.owner)?,
-        approvals: vec![],
-        token_uri: msg.token_uri,
-        extension: msg.extension,
-    };
-    contract
-        .tokens
-        .update(deps.storage, &msg.token_id, |old| match old {
-            Some(_) => Err(ContractError::Claimed {}),
-            None => Ok(token),
-        })?;
+    pub fn burn(
+        &self,
+        deps: DepsMut,
+        env: Env,
+        info: MessageInfo,
+        token_id: String,
+    ) -> Result<Response, ContractError> {
+        if !self.ready.load(deps.storage)? {
+            return Err(ContractError::NotReady {});
+        }
+        let token = self.parent.tokens.load(deps.storage, &token_id)?;
+        self.parent
+            .check_can_send(deps.as_ref(), &env, &info, &token)?;
 
-    contract.increment_tokens(deps.storage)?;
+        self.parent.tokens.remove(deps.storage, &token_id)?;
+        self.parent.decrement_tokens(deps.storage)?;
 
-    Ok(Response::new()
-        .add_attribute("action", "mint")
-        .add_attribute("minter", info.sender)
-        .add_attribute("owner", msg.owner)
-        .add_attribute("token_id", msg.token_id))
-}
+        let event = Event::new("burn")
+            .add_attribute("sender", info.sender)
+            .add_attribute("token_id", token_id);
+        let res = Response::new().add_event(event);
 
-pub fn query_collection_info(deps: Deps) -> StdResult<CollectionInfoResponse> {
-    let info = COLLECTION_INFO.load(deps.storage)?;
+        Ok(res)
+    }
 
-    let royalty_info_res: Option<RoyaltyInfoResponse> = match info.royalty_info {
-        Some(royalty_info) => Some(RoyaltyInfoResponse {
-            payment_address: royalty_info.payment_address.to_string(),
-            share: royalty_info.share,
-        }),
-        None => None,
-    };
+    pub fn revoke(
+        &self,
+        deps: DepsMut,
+        env: Env,
+        info: MessageInfo,
+        spender: String,
+        token_id: String,
+    ) -> Result<Response, ContractError> {
+        if !self.ready.load(deps.storage)? {
+            return Err(ContractError::NotReady {});
+        }
+        self.parent
+            ._update_approvals(deps, &env, &info, &spender, &token_id, false, None)?;
 
-    Ok(CollectionInfoResponse {
-        creator: info.creator,
-        description: info.description,
-        image: info.image,
-        external_link: info.external_link,
-        royalty_info: royalty_info_res,
-    })
+        let event = Event::new("revoke")
+            .add_attribute("sender", info.sender)
+            .add_attribute("spender", spender)
+            .add_attribute("token_id", token_id);
+        let res = Response::new().add_event(event);
+
+        Ok(res)
+    }
+
+    pub fn revoke_all(
+        &self,
+        deps: DepsMut,
+        _env: Env,
+        info: MessageInfo,
+        operator: String,
+    ) -> Result<Response, ContractError> {
+        if !self.ready.load(deps.storage)? {
+            return Err(ContractError::NotReady {});
+        }
+        let operator_addr = deps.api.addr_validate(&operator)?;
+        self.parent
+            .operators
+            .remove(deps.storage, (&info.sender, &operator_addr));
+
+        let event = Event::new("revoke_all")
+            .add_attribute("sender", info.sender)
+            .add_attribute("operator", operator);
+        let res = Response::new().add_event(event);
+
+        Ok(res)
+    }
+
+    pub fn send_nft(
+        &self,
+        deps: DepsMut,
+        env: Env,
+        info: MessageInfo,
+        receiving_contract: String,
+        token_id: String,
+        msg: Binary,
+    ) -> Result<Response, ContractError> {
+        if !self.ready.load(deps.storage)? {
+            return Err(ContractError::NotReady {});
+        }
+        // Transfer token
+        self.parent
+            ._transfer_nft(deps, &env, &info, &receiving_contract, &token_id)?;
+
+        let send = Cw721ReceiveMsg {
+            sender: info.sender.to_string(),
+            token_id: token_id.clone(),
+            msg,
+        };
+
+        // Send message
+        let event = Event::new("send_nft")
+            .add_attribute("sender", info.sender)
+            .add_attribute("recipient", receiving_contract.to_string())
+            .add_attribute("token_id", token_id);
+        let res = Response::new()
+            .add_message(send.into_cosmos_msg(receiving_contract)?)
+            .add_event(event);
+
+        Ok(res)
+    }
+
+    pub fn transfer_nft(
+        &self,
+        deps: DepsMut,
+        env: Env,
+        info: MessageInfo,
+        recipient: String,
+        token_id: String,
+    ) -> Result<Response, ContractError> {
+        if !self.ready.load(deps.storage)? {
+            return Err(ContractError::NotReady {});
+        }
+        self.parent
+            ._transfer_nft(deps, &env, &info, &recipient, &token_id)?;
+
+        let event = Event::new("transfer_nft")
+            .add_attribute("sender", info.sender)
+            .add_attribute("recipient", recipient)
+            .add_attribute("token_id", token_id);
+        let res = Response::new().add_event(event);
+
+        Ok(res)
+    }
+
+    pub fn mint(
+        &self,
+        deps: DepsMut,
+        _env: Env,
+        info: MessageInfo,
+        msg: MintMsg<T>,
+    ) -> Result<Response, ContractError> {
+        if !self.ready.load(deps.storage)? {
+            return Err(ContractError::NotReady {});
+        }
+        let minter = self.parent.minter.load(deps.storage)?;
+
+        if info.sender != minter {
+            return Err(ContractError::Unauthorized {});
+        }
+
+        // create the token
+        let token = TokenInfo {
+            owner: deps.api.addr_validate(&msg.owner)?,
+            approvals: vec![],
+            token_uri: msg.token_uri,
+            extension: msg.extension,
+        };
+        self.parent
+            .tokens
+            .update(deps.storage, &msg.token_id, |old| match old {
+                Some(_) => Err(ContractError::Claimed {}),
+                None => Ok(token),
+            })?;
+
+        self.parent.increment_tokens(deps.storage)?;
+
+        Ok(Response::new()
+            .add_attribute("action", "mint")
+            .add_attribute("minter", info.sender)
+            .add_attribute("owner", msg.owner)
+            .add_attribute("token_id", msg.token_id))
+    }
+
+    pub fn query(&self, deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
+        match msg {
+            QueryMsg::CollectionInfo {} => to_binary(&self.query_collection_info(deps)?),
+            _ => self.parent.query(deps, env, msg.into()),
+        }
+    }
+
+    pub fn query_collection_info(&self, deps: Deps) -> StdResult<CollectionInfoResponse> {
+        let info = self.collection_info.load(deps.storage)?;
+
+        let royalty_info_res: Option<RoyaltyInfoResponse> = match info.royalty_info {
+            Some(royalty_info) => Some(RoyaltyInfoResponse {
+                payment_address: royalty_info.payment_address.to_string(),
+                share: royalty_info.share,
+            }),
+            None => None,
+        };
+
+        Ok(CollectionInfoResponse {
+            creator: info.creator,
+            description: info.description,
+            image: info.image,
+            external_link: info.external_link,
+            royalty_info: royalty_info_res,
+        })
+    }
 }
 
 pub fn share_validate(share: Decimal) -> Result<Decimal, ContractError> {

--- a/contracts/sg721-base/src/contract.rs
+++ b/contracts/sg721-base/src/contract.rs
@@ -27,10 +27,7 @@ where
         _env: Env,
         info: MessageInfo,
         msg: InstantiateMsg,
-    ) -> Result<Response, ContractError>
-    where
-        T: Serialize + DeserializeOwned + Clone,
-    {
+    ) -> Result<Response, ContractError> {
         // no funds should be sent to this contract
         nonpayable(&info)?;
 

--- a/contracts/sg721-base/src/state.rs
+++ b/contracts/sg721-base/src/state.rs
@@ -1,7 +1,29 @@
 use cw_storage_plus::Item;
+use serde::{de::DeserializeOwned, Serialize};
 use sg721::{CollectionInfo, RoyaltyInfo};
+use sg_std::StargazeMsgWrapper;
 
-pub const COLLECTION_INFO: Item<CollectionInfo<RoyaltyInfo>> = Item::new("collection_info");
+pub struct Sg721Contract<'a, T>
+where
+    T: Serialize + DeserializeOwned + Clone,
+{
+    pub parent: cw721_base::Cw721Contract<'a, T, StargazeMsgWrapper>,
 
-/// Set to true by the minter to indicate the minter creation process is complete
-pub const READY: Item<bool> = Item::new("ready");
+    pub collection_info: Item<'a, CollectionInfo<RoyaltyInfo>>,
+
+    /// Set to true by the minter to indicate the minter creation process is complete
+    pub ready: Item<'a, bool>,
+}
+
+impl<'a, T> Default for Sg721Contract<'a, T>
+where
+    T: Serialize + DeserializeOwned + Clone,
+{
+    fn default() -> Self {
+        Sg721Contract {
+            parent: cw721_base::Cw721Contract::default(),
+            collection_info: Item::new("collection_info"),
+            ready: Item::new("ready"),
+        }
+    }
+}

--- a/contracts/sg721-metadata-onchain/.cargo/config
+++ b/contracts/sg721-metadata-onchain/.cargo/config
@@ -1,0 +1,4 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"
+unit-test = "test --lib"
+schema = "run --example schema"

--- a/contracts/sg721-metadata-onchain/Cargo.toml
+++ b/contracts/sg721-metadata-onchain/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
-name = "sg721-base"
+name = "sg721-metadata-onchain"
 version = "0.14.0"
-authors = ["Shane Vitarana <s@noreply.publicawesome.com>"]
+authors = [
+  "Shane Vitarana <s@noreply.publicawesome.com>",
+  "larry <gm@larry.engineer>"
+]
 edition = "2018"
-description = "Stargaze NFT collection contract"
+description = "Example extending SG721 NFT to store metadata on chain"
 license = "Apache-2.0"
 repository = "https://github.com/public-awesome/launchpad"
 homepage = "https://stargaze.zone"
@@ -33,14 +36,15 @@ cw2 = "0.13.4"
 schemars = "0.8.8"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.30" }
+sg-metadata = { path = "../../packages/sg-metadata" }
 sg-std = "0.14.0"
-url = "2.2.2"
-cw721 = "0.13.2"
-cw721-base = { version = "0.13.2", features = ["library"] }
 sg721 = "0.14.0"
+sg721-base = { path = "../sg721-base", features = ["library"] }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0" }
+cw721 = "0.13.4"
+cw721-base = { version = "0.13.4", features = ["library"] }
 cw-multi-test = "0.13.4"
 sg-multi-test = "0.15.1"
 vending-minter = { version = "0.14.0", features = ["library"] }

--- a/contracts/sg721-metadata-onchain/Cargo.toml
+++ b/contracts/sg721-metadata-onchain/Cargo.toml
@@ -30,12 +30,9 @@ library = []
 
 [dependencies]
 cosmwasm-std = { version = "1.0.0" }
-cw-storage-plus = "0.13.4"
-cw-utils = "0.13.4"
 cw2 = "0.13.4"
 schemars = "0.8.8"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
-thiserror = { version = "1.0.30" }
 sg-metadata = { path = "../../packages/sg-metadata" }
 sg-std = "0.14.0"
 sg721 = "0.14.0"
@@ -45,8 +42,3 @@ sg721-base = { path = "../sg721-base", features = ["library"] }
 cosmwasm-schema = { version = "1.0.0" }
 cw721 = "0.13.4"
 cw721-base = { version = "0.13.4", features = ["library"] }
-cw-multi-test = "0.13.4"
-sg-multi-test = "0.15.1"
-vending-minter = { version = "0.14.0", features = ["library"] }
-vending-factory = { version = "0.1.0", features = ["library"] }
-sg2 = "0.1.0"

--- a/contracts/sg721-metadata-onchain/examples/schema.rs
+++ b/contracts/sg721-metadata-onchain/examples/schema.rs
@@ -1,0 +1,41 @@
+use std::env::current_dir;
+use std::fs::create_dir_all;
+
+use cosmwasm_schema::{export_schema, export_schema_with_title, remove_schemas, schema_for};
+
+use cw721::{
+    AllNftInfoResponse, ApprovalResponse, ApprovalsResponse, ContractInfoResponse, NftInfoResponse,
+    NumTokensResponse, OperatorsResponse, OwnerOfResponse, TokensResponse,
+};
+use cw721_base::MinterResponse;
+use sg721_metadata_onchain::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use sg_metadata::Metadata;
+
+fn main() {
+    let mut out_dir = current_dir().unwrap();
+    out_dir.push("schema");
+    create_dir_all(&out_dir).unwrap();
+    remove_schemas(&out_dir).unwrap();
+
+    export_schema(&schema_for!(InstantiateMsg), &out_dir);
+    export_schema_with_title(&schema_for!(ExecuteMsg), &out_dir, "ExecuteMsg");
+    export_schema(&schema_for!(QueryMsg), &out_dir);
+    export_schema_with_title(
+        &schema_for!(AllNftInfoResponse<Metadata>),
+        &out_dir,
+        "AllNftInfoResponse",
+    );
+    export_schema(&schema_for!(ApprovalResponse), &out_dir);
+    export_schema(&schema_for!(ApprovalsResponse), &out_dir);
+    export_schema(&schema_for!(OperatorsResponse), &out_dir);
+    export_schema(&schema_for!(ContractInfoResponse), &out_dir);
+    export_schema(&schema_for!(MinterResponse), &out_dir);
+    export_schema_with_title(
+        &schema_for!(NftInfoResponse<Metadata>),
+        &out_dir,
+        "NftInfoResponse",
+    );
+    export_schema(&schema_for!(NumTokensResponse), &out_dir);
+    export_schema(&schema_for!(OwnerOfResponse), &out_dir);
+    export_schema(&schema_for!(TokensResponse), &out_dir);
+}

--- a/contracts/sg721-metadata-onchain/schema/all_nft_info_response.json
+++ b/contracts/sg721-metadata-onchain/schema/all_nft_info_response.json
@@ -1,0 +1,245 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AllNftInfoResponse",
+  "type": "object",
+  "required": [
+    "access",
+    "info"
+  ],
+  "properties": {
+    "access": {
+      "description": "Who can transfer the token",
+      "allOf": [
+        {
+          "$ref": "#/definitions/OwnerOfResponse"
+        }
+      ]
+    },
+    "info": {
+      "description": "Data on the token itself,",
+      "allOf": [
+        {
+          "$ref": "#/definitions/NftInfoResponse_for_Metadata"
+        }
+      ]
+    }
+  },
+  "definitions": {
+    "Approval": {
+      "type": "object",
+      "required": [
+        "expires",
+        "spender"
+      ],
+      "properties": {
+        "expires": {
+          "description": "When the Approval expires (maybe Expiration::never)",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            }
+          ]
+        },
+        "spender": {
+          "description": "Account that can transfer/send the token",
+          "type": "string"
+        }
+      }
+    },
+    "Expiration": {
+      "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+      "oneOf": [
+        {
+          "description": "AtHeight will expire when `env.block.height` >= height",
+          "type": "object",
+          "required": [
+            "at_height"
+          ],
+          "properties": {
+            "at_height": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "AtTime will expire when `env.block.time` >= time",
+          "type": "object",
+          "required": [
+            "at_time"
+          ],
+          "properties": {
+            "at_time": {
+              "$ref": "#/definitions/Timestamp"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Never will never expire. Used to express the empty variant",
+          "type": "object",
+          "required": [
+            "never"
+          ],
+          "properties": {
+            "never": {
+              "type": "object"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Metadata": {
+      "description": "OpenSea metadata standard, used by Stargaze marketplace. See [this link](https://docs.opensea.io/docs/metadata-standards) for details.",
+      "type": "object",
+      "properties": {
+        "animation_url": {
+          "description": "A URL to a multi-media attachment for the item. The file extensions GLTF, GLB, WEBM, MP4, M4V, OGV, and OGG are supported, along with the audio-only extensions MP3, WAV, and OGA.\n\nAnimation_url also supports HTML pages, allowing you to build rich experiences and interactive NFTs using JavaScript canvas, WebGL, and more. Scripts and relative paths within the HTML page are now supported. However, access to browser extensions is not supported.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "attributes": {
+          "description": "These are the attributes for the item, which will show up on the OpenSea page for the item.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Trait"
+          }
+        },
+        "background_color": {
+          "description": "Background color of the item on OpenSea. Must be a six-character hexadecimal without a pre-pended #.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "description": {
+          "description": "A human readable description of the item. Markdown is supported.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "external_url": {
+          "description": "This is the URL that will appear below the asset's image on OpenSea and will allow users to leave OpenSea and view the item on your site.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "image": {
+          "description": "This is the URL to the image of the item. Can be just about any type of image (including SVGs, which will be cached into PNGs by OpenSea), and can be [IPFS](https://github.com/ipfs/is-ipfs) URLs or paths. We recommend using a 350 x 350 image.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "image_data": {
+          "description": "Raw SVG image data, if you want to generate images on the fly (not recommended). Only use this if you're not including the `image` parameter.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "description": "Name of the item.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "youtube_url": {
+          "description": "A URL to a YouTube video.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "NftInfoResponse_for_Metadata": {
+      "type": "object",
+      "required": [
+        "extension"
+      ],
+      "properties": {
+        "extension": {
+          "description": "You can add any custom metadata here when you extend cw721-base",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Metadata"
+            }
+          ]
+        },
+        "token_uri": {
+          "description": "Universal resource identifier for this NFT Should point to a JSON file that conforms to the ERC721 Metadata JSON Schema",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "OwnerOfResponse": {
+      "type": "object",
+      "required": [
+        "approvals",
+        "owner"
+      ],
+      "properties": {
+        "approvals": {
+          "description": "If set this address is approved to transfer/send the token as well",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Approval"
+          }
+        },
+        "owner": {
+          "description": "Owner of the token",
+          "type": "string"
+        }
+      }
+    },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Trait": {
+      "description": "An attribute of the token as defined by the [OpenSea metadata standard](https://docs.opensea.io/docs/metadata-standards#attributes).",
+      "type": "object",
+      "required": [
+        "trait_type",
+        "value"
+      ],
+      "properties": {
+        "display_type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "trait_type": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/sg721-metadata-onchain/schema/approval_response.json
+++ b/contracts/sg721-metadata-onchain/schema/approval_response.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ApprovalResponse",
+  "type": "object",
+  "required": [
+    "approval"
+  ],
+  "properties": {
+    "approval": {
+      "$ref": "#/definitions/Approval"
+    }
+  },
+  "definitions": {
+    "Approval": {
+      "type": "object",
+      "required": [
+        "expires",
+        "spender"
+      ],
+      "properties": {
+        "expires": {
+          "description": "When the Approval expires (maybe Expiration::never)",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            }
+          ]
+        },
+        "spender": {
+          "description": "Account that can transfer/send the token",
+          "type": "string"
+        }
+      }
+    },
+    "Expiration": {
+      "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+      "oneOf": [
+        {
+          "description": "AtHeight will expire when `env.block.height` >= height",
+          "type": "object",
+          "required": [
+            "at_height"
+          ],
+          "properties": {
+            "at_height": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "AtTime will expire when `env.block.time` >= time",
+          "type": "object",
+          "required": [
+            "at_time"
+          ],
+          "properties": {
+            "at_time": {
+              "$ref": "#/definitions/Timestamp"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Never will never expire. Used to express the empty variant",
+          "type": "object",
+          "required": [
+            "never"
+          ],
+          "properties": {
+            "never": {
+              "type": "object"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/sg721-metadata-onchain/schema/approvals_response.json
+++ b/contracts/sg721-metadata-onchain/schema/approvals_response.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ApprovalsResponse",
+  "type": "object",
+  "required": [
+    "approvals"
+  ],
+  "properties": {
+    "approvals": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Approval"
+      }
+    }
+  },
+  "definitions": {
+    "Approval": {
+      "type": "object",
+      "required": [
+        "expires",
+        "spender"
+      ],
+      "properties": {
+        "expires": {
+          "description": "When the Approval expires (maybe Expiration::never)",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            }
+          ]
+        },
+        "spender": {
+          "description": "Account that can transfer/send the token",
+          "type": "string"
+        }
+      }
+    },
+    "Expiration": {
+      "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+      "oneOf": [
+        {
+          "description": "AtHeight will expire when `env.block.height` >= height",
+          "type": "object",
+          "required": [
+            "at_height"
+          ],
+          "properties": {
+            "at_height": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "AtTime will expire when `env.block.time` >= time",
+          "type": "object",
+          "required": [
+            "at_time"
+          ],
+          "properties": {
+            "at_time": {
+              "$ref": "#/definitions/Timestamp"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Never will never expire. Used to express the empty variant",
+          "type": "object",
+          "required": [
+            "never"
+          ],
+          "properties": {
+            "never": {
+              "type": "object"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/sg721-metadata-onchain/schema/contract_info_response.json
+++ b/contracts/sg721-metadata-onchain/schema/contract_info_response.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ContractInfoResponse",
+  "type": "object",
+  "required": [
+    "name",
+    "symbol"
+  ],
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "symbol": {
+      "type": "string"
+    }
+  }
+}

--- a/contracts/sg721-metadata-onchain/schema/execute_msg.json
+++ b/contracts/sg721-metadata-onchain/schema/execute_msg.json
@@ -1,0 +1,410 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ExecuteMsg",
+  "oneOf": [
+    {
+      "description": "Called by the minter to put a collection contract in the ready state. When ready it means the factory and minter are properly setup.",
+      "type": "object",
+      "required": [
+        "__ready"
+      ],
+      "properties": {
+        "__ready": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Transfer is a base message to move a token to another account without triggering actions",
+      "type": "object",
+      "required": [
+        "transfer_nft"
+      ],
+      "properties": {
+        "transfer_nft": {
+          "type": "object",
+          "required": [
+            "recipient",
+            "token_id"
+          ],
+          "properties": {
+            "recipient": {
+              "type": "string"
+            },
+            "token_id": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Send is a base message to transfer a token to a contract and trigger an action on the receiving contract.",
+      "type": "object",
+      "required": [
+        "send_nft"
+      ],
+      "properties": {
+        "send_nft": {
+          "type": "object",
+          "required": [
+            "contract",
+            "msg",
+            "token_id"
+          ],
+          "properties": {
+            "contract": {
+              "type": "string"
+            },
+            "msg": {
+              "$ref": "#/definitions/Binary"
+            },
+            "token_id": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Allows operator to transfer / send the token from the owner's account. If expiration is set, then this allowance has a time/height limit",
+      "type": "object",
+      "required": [
+        "approve"
+      ],
+      "properties": {
+        "approve": {
+          "type": "object",
+          "required": [
+            "spender",
+            "token_id"
+          ],
+          "properties": {
+            "expires": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Expiration"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "spender": {
+              "type": "string"
+            },
+            "token_id": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Remove previously granted Approval",
+      "type": "object",
+      "required": [
+        "revoke"
+      ],
+      "properties": {
+        "revoke": {
+          "type": "object",
+          "required": [
+            "spender",
+            "token_id"
+          ],
+          "properties": {
+            "spender": {
+              "type": "string"
+            },
+            "token_id": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Allows operator to transfer / send any token from the owner's account. If expiration is set, then this allowance has a time/height limit",
+      "type": "object",
+      "required": [
+        "approve_all"
+      ],
+      "properties": {
+        "approve_all": {
+          "type": "object",
+          "required": [
+            "operator"
+          ],
+          "properties": {
+            "expires": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Expiration"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "operator": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Remove previously granted ApproveAll permission",
+      "type": "object",
+      "required": [
+        "revoke_all"
+      ],
+      "properties": {
+        "revoke_all": {
+          "type": "object",
+          "required": [
+            "operator"
+          ],
+          "properties": {
+            "operator": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Mint a new NFT, can only be called by the contract minter",
+      "type": "object",
+      "required": [
+        "mint"
+      ],
+      "properties": {
+        "mint": {
+          "$ref": "#/definitions/MintMsg_for_Metadata"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Burn an NFT the sender has access to",
+      "type": "object",
+      "required": [
+        "burn"
+      ],
+      "properties": {
+        "burn": {
+          "type": "object",
+          "required": [
+            "token_id"
+          ],
+          "properties": {
+            "token_id": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "definitions": {
+    "Binary": {
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
+      "type": "string"
+    },
+    "Expiration": {
+      "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+      "oneOf": [
+        {
+          "description": "AtHeight will expire when `env.block.height` >= height",
+          "type": "object",
+          "required": [
+            "at_height"
+          ],
+          "properties": {
+            "at_height": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "AtTime will expire when `env.block.time` >= time",
+          "type": "object",
+          "required": [
+            "at_time"
+          ],
+          "properties": {
+            "at_time": {
+              "$ref": "#/definitions/Timestamp"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Never will never expire. Used to express the empty variant",
+          "type": "object",
+          "required": [
+            "never"
+          ],
+          "properties": {
+            "never": {
+              "type": "object"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Metadata": {
+      "description": "OpenSea metadata standard, used by Stargaze marketplace. See [this link](https://docs.opensea.io/docs/metadata-standards) for details.",
+      "type": "object",
+      "properties": {
+        "animation_url": {
+          "description": "A URL to a multi-media attachment for the item. The file extensions GLTF, GLB, WEBM, MP4, M4V, OGV, and OGG are supported, along with the audio-only extensions MP3, WAV, and OGA.\n\nAnimation_url also supports HTML pages, allowing you to build rich experiences and interactive NFTs using JavaScript canvas, WebGL, and more. Scripts and relative paths within the HTML page are now supported. However, access to browser extensions is not supported.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "attributes": {
+          "description": "These are the attributes for the item, which will show up on the OpenSea page for the item.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Trait"
+          }
+        },
+        "background_color": {
+          "description": "Background color of the item on OpenSea. Must be a six-character hexadecimal without a pre-pended #.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "description": {
+          "description": "A human readable description of the item. Markdown is supported.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "external_url": {
+          "description": "This is the URL that will appear below the asset's image on OpenSea and will allow users to leave OpenSea and view the item on your site.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "image": {
+          "description": "This is the URL to the image of the item. Can be just about any type of image (including SVGs, which will be cached into PNGs by OpenSea), and can be [IPFS](https://github.com/ipfs/is-ipfs) URLs or paths. We recommend using a 350 x 350 image.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "image_data": {
+          "description": "Raw SVG image data, if you want to generate images on the fly (not recommended). Only use this if you're not including the `image` parameter.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "description": "Name of the item.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "youtube_url": {
+          "description": "A URL to a YouTube video.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "MintMsg_for_Metadata": {
+      "type": "object",
+      "required": [
+        "extension",
+        "owner",
+        "token_id"
+      ],
+      "properties": {
+        "extension": {
+          "description": "Any custom extension used by this contract",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Metadata"
+            }
+          ]
+        },
+        "owner": {
+          "description": "The owner of the newly minter NFT",
+          "type": "string"
+        },
+        "token_id": {
+          "description": "Unique ID of the NFT",
+          "type": "string"
+        },
+        "token_uri": {
+          "description": "Universal resource identifier for this NFT Should point to a JSON file that conforms to the ERC721 Metadata JSON Schema",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Trait": {
+      "description": "An attribute of the token as defined by the [OpenSea metadata standard](https://docs.opensea.io/docs/metadata-standards#attributes).",
+      "type": "object",
+      "required": [
+        "trait_type",
+        "value"
+      ],
+      "properties": {
+        "display_type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "trait_type": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/sg721-metadata-onchain/schema/instantiate_msg.json
+++ b/contracts/sg721-metadata-onchain/schema/instantiate_msg.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "InstantiateMsg",
+  "type": "object",
+  "required": [
+    "collection_info",
+    "minter",
+    "name",
+    "symbol"
+  ],
+  "properties": {
+    "collection_info": {
+      "$ref": "#/definitions/CollectionInfo_for_RoyaltyInfoResponse"
+    },
+    "minter": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "symbol": {
+      "type": "string"
+    }
+  },
+  "definitions": {
+    "CollectionInfo_for_RoyaltyInfoResponse": {
+      "type": "object",
+      "required": [
+        "creator",
+        "description",
+        "image"
+      ],
+      "properties": {
+        "creator": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "external_link": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "image": {
+          "type": "string"
+        },
+        "royalty_info": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RoyaltyInfoResponse"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "Decimal": {
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "type": "string"
+    },
+    "RoyaltyInfoResponse": {
+      "type": "object",
+      "required": [
+        "payment_address",
+        "share"
+      ],
+      "properties": {
+        "payment_address": {
+          "type": "string"
+        },
+        "share": {
+          "$ref": "#/definitions/Decimal"
+        }
+      }
+    }
+  }
+}

--- a/contracts/sg721-metadata-onchain/schema/minter_response.json
+++ b/contracts/sg721-metadata-onchain/schema/minter_response.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MinterResponse",
+  "description": "Shows who can mint these tokens",
+  "type": "object",
+  "required": [
+    "minter"
+  ],
+  "properties": {
+    "minter": {
+      "type": "string"
+    }
+  }
+}

--- a/contracts/sg721-metadata-onchain/schema/nft_info_response.json
+++ b/contracts/sg721-metadata-onchain/schema/nft_info_response.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "NftInfoResponse",
+  "type": "object",
+  "required": [
+    "extension"
+  ],
+  "properties": {
+    "extension": {
+      "description": "You can add any custom metadata here when you extend cw721-base",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Metadata"
+        }
+      ]
+    },
+    "token_uri": {
+      "description": "Universal resource identifier for this NFT Should point to a JSON file that conforms to the ERC721 Metadata JSON Schema",
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "definitions": {
+    "Metadata": {
+      "description": "OpenSea metadata standard, used by Stargaze marketplace. See [this link](https://docs.opensea.io/docs/metadata-standards) for details.",
+      "type": "object",
+      "properties": {
+        "animation_url": {
+          "description": "A URL to a multi-media attachment for the item. The file extensions GLTF, GLB, WEBM, MP4, M4V, OGV, and OGG are supported, along with the audio-only extensions MP3, WAV, and OGA.\n\nAnimation_url also supports HTML pages, allowing you to build rich experiences and interactive NFTs using JavaScript canvas, WebGL, and more. Scripts and relative paths within the HTML page are now supported. However, access to browser extensions is not supported.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "attributes": {
+          "description": "These are the attributes for the item, which will show up on the OpenSea page for the item.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Trait"
+          }
+        },
+        "background_color": {
+          "description": "Background color of the item on OpenSea. Must be a six-character hexadecimal without a pre-pended #.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "description": {
+          "description": "A human readable description of the item. Markdown is supported.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "external_url": {
+          "description": "This is the URL that will appear below the asset's image on OpenSea and will allow users to leave OpenSea and view the item on your site.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "image": {
+          "description": "This is the URL to the image of the item. Can be just about any type of image (including SVGs, which will be cached into PNGs by OpenSea), and can be [IPFS](https://github.com/ipfs/is-ipfs) URLs or paths. We recommend using a 350 x 350 image.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "image_data": {
+          "description": "Raw SVG image data, if you want to generate images on the fly (not recommended). Only use this if you're not including the `image` parameter.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "description": "Name of the item.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "youtube_url": {
+          "description": "A URL to a YouTube video.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "Trait": {
+      "description": "An attribute of the token as defined by the [OpenSea metadata standard](https://docs.opensea.io/docs/metadata-standards#attributes).",
+      "type": "object",
+      "required": [
+        "trait_type",
+        "value"
+      ],
+      "properties": {
+        "display_type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "trait_type": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/contracts/sg721-metadata-onchain/schema/num_tokens_response.json
+++ b/contracts/sg721-metadata-onchain/schema/num_tokens_response.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "NumTokensResponse",
+  "type": "object",
+  "required": [
+    "count"
+  ],
+  "properties": {
+    "count": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    }
+  }
+}

--- a/contracts/sg721-metadata-onchain/schema/operators_response.json
+++ b/contracts/sg721-metadata-onchain/schema/operators_response.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OperatorsResponse",
+  "type": "object",
+  "required": [
+    "operators"
+  ],
+  "properties": {
+    "operators": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Approval"
+      }
+    }
+  },
+  "definitions": {
+    "Approval": {
+      "type": "object",
+      "required": [
+        "expires",
+        "spender"
+      ],
+      "properties": {
+        "expires": {
+          "description": "When the Approval expires (maybe Expiration::never)",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            }
+          ]
+        },
+        "spender": {
+          "description": "Account that can transfer/send the token",
+          "type": "string"
+        }
+      }
+    },
+    "Expiration": {
+      "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+      "oneOf": [
+        {
+          "description": "AtHeight will expire when `env.block.height` >= height",
+          "type": "object",
+          "required": [
+            "at_height"
+          ],
+          "properties": {
+            "at_height": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "AtTime will expire when `env.block.time` >= time",
+          "type": "object",
+          "required": [
+            "at_time"
+          ],
+          "properties": {
+            "at_time": {
+              "$ref": "#/definitions/Timestamp"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Never will never expire. Used to express the empty variant",
+          "type": "object",
+          "required": [
+            "never"
+          ],
+          "properties": {
+            "never": {
+              "type": "object"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/sg721-metadata-onchain/schema/owner_of_response.json
+++ b/contracts/sg721-metadata-onchain/schema/owner_of_response.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OwnerOfResponse",
+  "type": "object",
+  "required": [
+    "approvals",
+    "owner"
+  ],
+  "properties": {
+    "approvals": {
+      "description": "If set this address is approved to transfer/send the token as well",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Approval"
+      }
+    },
+    "owner": {
+      "description": "Owner of the token",
+      "type": "string"
+    }
+  },
+  "definitions": {
+    "Approval": {
+      "type": "object",
+      "required": [
+        "expires",
+        "spender"
+      ],
+      "properties": {
+        "expires": {
+          "description": "When the Approval expires (maybe Expiration::never)",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            }
+          ]
+        },
+        "spender": {
+          "description": "Account that can transfer/send the token",
+          "type": "string"
+        }
+      }
+    },
+    "Expiration": {
+      "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+      "oneOf": [
+        {
+          "description": "AtHeight will expire when `env.block.height` >= height",
+          "type": "object",
+          "required": [
+            "at_height"
+          ],
+          "properties": {
+            "at_height": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "AtTime will expire when `env.block.time` >= time",
+          "type": "object",
+          "required": [
+            "at_time"
+          ],
+          "properties": {
+            "at_time": {
+              "$ref": "#/definitions/Timestamp"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Never will never expire. Used to express the empty variant",
+          "type": "object",
+          "required": [
+            "never"
+          ],
+          "properties": {
+            "never": {
+              "type": "object"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/sg721-metadata-onchain/schema/query_msg.json
+++ b/contracts/sg721-metadata-onchain/schema/query_msg.json
@@ -1,0 +1,284 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "QueryMsg",
+  "oneOf": [
+    {
+      "type": "object",
+      "required": [
+        "owner_of"
+      ],
+      "properties": {
+        "owner_of": {
+          "type": "object",
+          "required": [
+            "token_id"
+          ],
+          "properties": {
+            "include_expired": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "token_id": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "approval"
+      ],
+      "properties": {
+        "approval": {
+          "type": "object",
+          "required": [
+            "spender",
+            "token_id"
+          ],
+          "properties": {
+            "include_expired": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "spender": {
+              "type": "string"
+            },
+            "token_id": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "approvals"
+      ],
+      "properties": {
+        "approvals": {
+          "type": "object",
+          "required": [
+            "token_id"
+          ],
+          "properties": {
+            "include_expired": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "token_id": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "all_operators"
+      ],
+      "properties": {
+        "all_operators": {
+          "type": "object",
+          "required": [
+            "owner"
+          ],
+          "properties": {
+            "include_expired": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "limit": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "owner": {
+              "type": "string"
+            },
+            "start_after": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "num_tokens"
+      ],
+      "properties": {
+        "num_tokens": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "contract_info"
+      ],
+      "properties": {
+        "contract_info": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "nft_info"
+      ],
+      "properties": {
+        "nft_info": {
+          "type": "object",
+          "required": [
+            "token_id"
+          ],
+          "properties": {
+            "token_id": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "all_nft_info"
+      ],
+      "properties": {
+        "all_nft_info": {
+          "type": "object",
+          "required": [
+            "token_id"
+          ],
+          "properties": {
+            "include_expired": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "token_id": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "tokens"
+      ],
+      "properties": {
+        "tokens": {
+          "type": "object",
+          "required": [
+            "owner"
+          ],
+          "properties": {
+            "limit": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "owner": {
+              "type": "string"
+            },
+            "start_after": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "all_tokens"
+      ],
+      "properties": {
+        "all_tokens": {
+          "type": "object",
+          "properties": {
+            "limit": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "start_after": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "minter"
+      ],
+      "properties": {
+        "minter": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "collection_info"
+      ],
+      "properties": {
+        "collection_info": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    }
+  ]
+}

--- a/contracts/sg721-metadata-onchain/schema/tokens_response.json
+++ b/contracts/sg721-metadata-onchain/schema/tokens_response.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "TokensResponse",
+  "type": "object",
+  "required": [
+    "tokens"
+  ],
+  "properties": {
+    "tokens": {
+      "description": "Contains all token_ids in lexicographical ordering If there are more than `limit`, use `start_from` in future queries to achieve pagination.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/contracts/sg721-metadata-onchain/src/lib.rs
+++ b/contracts/sg721-metadata-onchain/src/lib.rs
@@ -1,0 +1,116 @@
+pub use sg721_base::ContractError;
+use sg_metadata::Metadata;
+
+// version info for migration info
+const CONTRACT_NAME: &str = "crates.io:sg721-metadata-onchain";
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+pub type Sg721MetadataContract<'a> = sg721_base::Sg721Contract<'a, Metadata>;
+pub type InstantiateMsg = sg721::InstantiateMsg;
+pub type ExecuteMsg = sg721::ExecuteMsg<Metadata>;
+pub type QueryMsg = sg721_base::msg::QueryMsg;
+
+#[cfg(not(feature = "library"))]
+pub mod entry {
+    use super::*;
+
+    use cosmwasm_std::{entry_point, Binary, Deps, DepsMut, Env, MessageInfo, StdResult};
+    use sg721_base::{msg::QueryMsg, ContractError};
+    use sg_std::Response;
+
+    #[entry_point]
+    pub fn instantiate(
+        deps: DepsMut,
+        env: Env,
+        info: MessageInfo,
+        msg: InstantiateMsg,
+    ) -> Result<Response, ContractError> {
+        cw2::set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+        let res = Sg721MetadataContract::default().instantiate(deps, env, info, msg)?;
+
+        Ok(res
+            .add_attribute("contract_name", CONTRACT_NAME)
+            .add_attribute("contract_version", CONTRACT_VERSION))
+    }
+
+    #[entry_point]
+    pub fn execute(
+        deps: DepsMut,
+        env: Env,
+        info: MessageInfo,
+        msg: ExecuteMsg,
+    ) -> Result<Response, ContractError> {
+        Sg721MetadataContract::default().execute(deps, env, info, msg)
+    }
+
+    #[entry_point]
+    pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
+        Sg721MetadataContract::default().query(deps, env, msg)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+    use cw721::Cw721Query;
+    use sg721::{CollectionInfo, ExecuteMsg, InstantiateMsg, MintMsg};
+
+    const CREATOR: &str = "creator";
+
+    #[test]
+    fn use_metadata_extension() {
+        let mut deps = mock_dependencies();
+        let contract = Sg721MetadataContract::default();
+
+        // instantiate contract
+        let info = mock_info(CREATOR, &[]);
+        let init_msg = InstantiateMsg {
+            name: "SpaceShips".to_string(),
+            symbol: "SPACE".to_string(),
+            minter: CREATOR.to_string(),
+            collection_info: CollectionInfo {
+                creator: CREATOR.to_string(),
+                description: "this is a test".to_string(),
+                image: "https://larry.engineer".to_string(),
+                external_link: None,
+                royalty_info: None,
+            },
+        };
+        contract
+            .instantiate(deps.as_mut(), mock_env(), info.clone(), init_msg)
+            .unwrap();
+
+        // set contract to ready
+        contract
+            .ready(deps.as_mut(), mock_env(), info.clone())
+            .unwrap();
+
+        // mint token
+        let token_id = "Enterprise";
+        let mint_msg = MintMsg {
+            token_id: token_id.to_string(),
+            owner: "john".to_string(),
+            token_uri: Some("https://starships.example.com/Starship/Enterprise.json".into()),
+            extension: Metadata {
+                description: Some("Spaceship with Warp Drive".into()),
+                name: Some("Starship USS Enterprise".to_string()),
+                ..Metadata::default()
+            },
+        };
+        let exec_msg = ExecuteMsg::Mint(mint_msg.clone());
+        contract
+            .execute(deps.as_mut(), mock_env(), info, exec_msg)
+            .unwrap();
+
+        // check token contains correct metadata
+        let res = contract
+            .parent
+            .nft_info(deps.as_ref(), token_id.into())
+            .unwrap();
+        assert_eq!(res.token_uri, mint_msg.token_uri);
+        assert_eq!(res.extension, mint_msg.extension);
+    }
+}

--- a/packages/sg-metadata/Cargo.toml
+++ b/packages/sg-metadata/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "sg-metadata"
+version = "0.14.0"
+authors = [
+  "Shane Vitarana <s@noreply.publicawsome.com>",
+  "larry <gm@larry.engineer>"
+]
+edition = "2018"
+description = "Rust definition of the OpenSea metadata standard, used by Stargaze marketplace"
+license = "Apache-2.0"
+repository = "https://github.com/public-awesome/launchpad"
+homepage = "https://stargaze.zone"
+
+exclude = [
+  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+  "contract.wasm",
+  "hash.txt",
+]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+schemars = "0.8.8"
+serde = { version = "1.0.137", default-features = false, features = ["derive"] }

--- a/packages/sg-metadata/src/lib.rs
+++ b/packages/sg-metadata/src/lib.rs
@@ -1,0 +1,45 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// An attribute of the token as defined by the
+/// [OpenSea metadata standard](https://docs.opensea.io/docs/metadata-standards#attributes).
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct Trait {
+    pub display_type: Option<String>,
+    pub trait_type: String,
+    pub value: String,
+}
+
+/// OpenSea metadata standard, used by Stargaze marketplace.
+/// See [this link](https://docs.opensea.io/docs/metadata-standards) for details.
+#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, JsonSchema)]
+pub struct Metadata {
+    /// This is the URL to the image of the item. Can be just about any type of image (including
+    /// SVGs, which will be cached into PNGs by OpenSea), and can be
+    /// [IPFS](https://github.com/ipfs/is-ipfs) URLs or paths. We recommend using a 350 x 350 image.
+    pub image: Option<String>,
+    /// Raw SVG image data, if you want to generate images on the fly (not recommended). Only use
+    /// this if you're not including the `image` parameter.
+    pub image_data: Option<String>,
+    /// This is the URL that will appear below the asset's image on OpenSea and will allow users to
+    /// leave OpenSea and view the item on your site.
+    pub external_url: Option<String>,
+    /// A human readable description of the item. Markdown is supported.
+    pub description: Option<String>,
+    /// Name of the item.
+    pub name: Option<String>,
+    /// These are the attributes for the item, which will show up on the OpenSea page for the item.
+    pub attributes: Option<Vec<Trait>>,
+    /// Background color of the item on OpenSea. Must be a six-character hexadecimal without a
+    /// pre-pended #.
+    pub background_color: Option<String>,
+    /// A URL to a multi-media attachment for the item. The file extensions GLTF, GLB, WEBM, MP4,
+    /// M4V, OGV, and OGG are supported, along with the audio-only extensions MP3, WAV, and OGA.
+    ///
+    /// Animation_url also supports HTML pages, allowing you to build rich experiences and
+    /// interactive NFTs using JavaScript canvas, WebGL, and more. Scripts and relative paths within
+    /// the HTML page are now supported. However, access to browser extensions is not supported.
+    pub animation_url: Option<String>,
+    /// A URL to a YouTube video.
+    pub youtube_url: Option<String>,
+}


### PR DESCRIPTION
I am developing an NFT project that will store metadata on-chain. However, while working with the `sg721-base` contract, i found it is structured in a way that is not very extensible, i.e. hard to build NFTs with custom logics on top of it.

This PR:
* refactors `sg721-base` to make it more extensible
* adds `sg-metadata` package which contains Rust definition of the OpenSea metadata standard
* adds `sg721-metadata-onchain` contract to demonstrate how to extend the refactored `sg721-base` and store metadata on-chain
* bumps `sg721-base` version to 0.14 as this is a somewhat major change (can revert if you don't like this)

## Refactoring of `sg721-base`

Replace `Cw721Base` with a new `Sg721Contract` struct, which holds the `cw721_base::Cw721Contract` as "parent", as well as two storage variables introduced by SG-721. The extension can be provided as a generic `T`:

```rust
pub struct Sg721Contract<'a, T>
where
    T: Serialize + DeserializeOwned + Clone,
{
    // inherit the vanilla CW-721 base
    pub parent: cw721_base::Cw721Contract<'a, T, StargazeMsgWrapper>,

    // the two new storage variables introduced by SG-721 on top of CW-721
    pub collection_info: Item<'a, CollectionInfo<RoyaltyInfo>>,
    pub ready: Item<'a, bool>,
}
```

the execution functions are now implemented as methods of the `Sg721Contract` struct. For example:

```rust
impl<'a, T> Sg721Contract<'a, T>
where
    T: Serialize + DeserializeOwned + Clone,
{
     pub fn ready(
        &self,
        deps: DepsMut,
        _env: Env,
        info: MessageInfo,
    ) -> Result<Response, ContractError> {
        // ...
    }
}
```

## Extending the refactored `sg721-base`

There are two ways to extend this contract. To set a custom extension without altering the base contract's logics, simply specify the generic. The `sg721-metadata-onchain` demo uses this approach:

```rust
use sg721_base::Sg721Contract;
use sg_metadata::Metadata;

pub type Sg721MetadataContract<'a> = Sg721Contract<'a, Metadata>;
```

To alter the base contract's logics, implement a "wrapper struct":

```rust
use sg721_base::Sg721Contract;

#[derive(Default)]
struct MyCustomNft(Sg721Contract);

impl MyCustomNft {
    // implement custom minting logic
    pub fn mint(
        &self,
        deps: DepsMut,
        _env: Env,
        info: MessageInfo,
        msg: MintMsg<T>,
    ) -> Result<Response, ContractError> {
        // ...
    }

    // for functions that don't need to be customized, simply dispatch to parent
    pub fn transfer_nft(
        &self,
        deps: DepsMut,
        env: Env,
        info: MessageInfo,
        recipient: String,
        token_id: String,
    ) -> Result<Response, ContractError> {
        self.0.transfer_nft(deps, env, info, recipient, token_id)
    }
}
``` 

## Note

Currently there is an unresolved clippy warning:

```
    Checking sg-metadata v0.14.0 (/Users/larry/workspace/stargaze-launchpad/packages/sg-metadata)
warning: you are deriving `PartialEq` and can implement `Eq`
 --> packages/sg-metadata/src/lib.rs:6:48
  |
6 | #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
  |                                                ^^^^^^^^^ help: consider deriving `Eq` as well: `PartialEq, Eq`
  |
  = note: `#[warn(clippy::derive_partial_eq_without_eq)]` on by default
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq

warning: `sg-metadata` (lib) generated 1 warning
```

Which suggests deriving the `Eq` trait for several message types. However, none of the core cosmwasm package derives this trait, so i left this unchanged.