### PR TITLE
Create group within splits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
  "cw2 0.13.4",
  "schemars",
  "serde",
- "sg-multi-test 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sg-multi-test 0.15.1",
  "sg-std 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sg1 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sg2",
@@ -54,7 +54,7 @@ dependencies = [
  "cw721-base",
  "schemars",
  "serde",
- "sg-multi-test 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sg-multi-test 0.15.1",
  "sg-std 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sg1 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sg2",
@@ -986,6 +986,8 @@ dependencies = [
 [[package]]
 name = "sg-multi-test"
 version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13db39357dc21338185c8c2ef2e4536127d7ebca30fcb44026eb5d59f83c1ffd"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
@@ -997,9 +999,21 @@ dependencies = [
 
 [[package]]
 name = "sg-multi-test"
-version = "0.15.1"
+version = "0.16.0"
+dependencies = [
+ "anyhow",
+ "cosmwasm-std",
+ "cw-multi-test",
+ "schemars",
+ "serde",
+ "sg-std 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sg-multi-test"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13db39357dc21338185c8c2ef2e4536127d7ebca30fcb44026eb5d59f83c1ffd"
+checksum = "c9801b53d4f04d470942a9587c56f1a176d28fba4689645a6941f50cac265b3c"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
@@ -1026,8 +1040,8 @@ dependencies = [
  "cw4-group",
  "schemars",
  "serde",
- "sg-multi-test 0.15.1",
- "sg-std 0.14.0",
+ "sg-multi-test 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sg-std 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
 
@@ -1211,7 +1225,7 @@ dependencies = [
  "cw721-base",
  "schemars",
  "serde",
- "sg-multi-test 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sg-multi-test 0.15.1",
  "sg-std 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sg2",
  "sg721 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1431,7 +1445,7 @@ dependencies = [
  "cw2 0.13.4",
  "schemars",
  "serde",
- "sg-multi-test 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sg-multi-test 0.15.1",
  "sg-std 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sg1 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sg2",
@@ -1457,7 +1471,7 @@ dependencies = [
  "rand_xoshiro",
  "schemars",
  "serde",
- "sg-multi-test 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sg-multi-test 0.15.1",
  "sg-splits",
  "sg-std 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sg-whitelist 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,20 +276,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cw-controllers"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b81b8c4647f13be38baea7345885fcd97cffe8ad4e0454a43f975be9609127ed"
-dependencies = [
- "cosmwasm-std",
- "cw-storage-plus 0.14.0",
- "cw-utils 0.14.0",
- "schemars",
- "serde",
- "thiserror",
-]
-
-[[package]]
 name = "cw-multi-test"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +368,18 @@ dependencies = [
 
 [[package]]
 name = "cw3"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe19462a7f644ba60c19d3443cb90d00c50d9b6b3b0a3a7fca93df8261af979b"
+dependencies = [
+ "cosmwasm-std",
+ "cw-utils 0.13.4",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "cw3"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c387f56a69bd3ad3bf9e13bb7bd638668a78b4eae9aecaa6a8ab3f7542051f7"
@@ -402,7 +400,7 @@ dependencies = [
  "cw-storage-plus 0.14.0",
  "cw-utils 0.14.0",
  "cw2 0.14.0",
- "cw3",
+ "cw3 0.14.0",
  "schemars",
  "serde",
  "thiserror",
@@ -418,7 +416,7 @@ dependencies = [
  "cw-storage-plus 0.14.0",
  "cw-utils 0.14.0",
  "cw2 0.14.0",
- "cw3",
+ "cw3 0.14.0",
  "cw3-fixed-multisig",
  "cw4 0.14.0",
  "schemars",
@@ -457,28 +455,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6c95c89153e7831c8306c8eba40a3daa76f9c7b8f5179dd0b8628aca168ec7a"
 dependencies = [
  "cosmwasm-std",
- "cw-controllers 0.13.4",
+ "cw-controllers",
  "cw-storage-plus 0.13.4",
  "cw-utils 0.13.4",
  "cw2 0.13.4",
  "cw4 0.13.4",
- "schemars",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "cw4-group"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93204a7aa587466636d001b21831c4b4ac87fccd40c7b39f78ad95dee452309e"
-dependencies = [
- "cosmwasm-std",
- "cw-controllers 0.14.0",
- "cw-storage-plus 0.14.0",
- "cw-utils 0.14.0",
- "cw2 0.14.0",
- "cw4 0.14.0",
  "schemars",
  "serde",
  "thiserror",
@@ -1037,11 +1018,12 @@ dependencies = [
  "cosmwasm-storage",
  "cw-multi-test",
  "cw-storage-plus 0.13.4",
+ "cw-utils 0.14.0",
  "cw2 0.13.4",
- "cw3",
+ "cw3 0.13.4",
  "cw3-flex-multisig",
- "cw4 0.14.0",
- "cw4-group 0.14.0",
+ "cw4 0.13.4",
+ "cw4-group",
  "schemars",
  "serde",
  "sg-multi-test 0.15.1",
@@ -1468,7 +1450,7 @@ dependencies = [
  "cw-utils 0.13.4",
  "cw2 0.13.4",
  "cw4 0.13.4",
- "cw4-group 0.13.4",
+ "cw4-group",
  "cw721",
  "cw721-base",
  "rand_core 0.6.3",

--- a/contracts/splits/Cargo.toml
+++ b/contracts/splits/Cargo.toml
@@ -45,15 +45,17 @@ cosmwasm-storage = "1.0.0"
 cw-storage-plus = "0.13.2"
 cw2 = "0.13.2"
 cw3-flex-multisig = { version = "0.14.0", features = ["library"] }
+cw-utils = "0.14.0"
 schemars = "0.8.8"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.31" }
-cw4 = "0.14.0"
-cw3 = "0.14.0"
+cw4 = "0.13.2"
+cw3 = "0.13.2"
 sg-std = { path = "../../packages/sg-std" }
+cw4-group = { version = "0.13.2", features = ["library"] }
 
 [dev-dependencies]
 cosmwasm-schema = "1.0.0"
 cw-multi-test = "0.13.2"
-cw4-group = "0.14.0"
+cw4-group = "0.13.2"
 sg-multi-test = { path = "../../packages/sg-multi-test" }

--- a/contracts/splits/Cargo.toml
+++ b/contracts/splits/Cargo.toml
@@ -51,11 +51,11 @@ serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.31" }
 cw4 = "0.13.2"
 cw3 = "0.13.2"
-sg-std = { path = "../../packages/sg-std" }
+sg-std = "0.14.0"
 cw4-group = { version = "0.13.2", features = ["library"] }
 
 [dev-dependencies]
 cosmwasm-schema = "1.0.0"
 cw-multi-test = "0.13.2"
 cw4-group = "0.13.2"
-sg-multi-test = { path = "../../packages/sg-multi-test" }
+sg-multi-test = "0.16.0"

--- a/contracts/splits/examples/schema.rs
+++ b/contracts/splits/examples/schema.rs
@@ -4,7 +4,6 @@ use std::fs::create_dir_all;
 use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
 
 use sg_splits::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
-use sg_splits::state::Config;
 
 fn main() {
     let mut out_dir = current_dir().unwrap();
@@ -15,5 +14,4 @@ fn main() {
     export_schema(&schema_for!(InstantiateMsg), &out_dir);
     export_schema(&schema_for!(ExecuteMsg), &out_dir);
     export_schema(&schema_for!(QueryMsg), &out_dir);
-    export_schema(&schema_for!(Config), &out_dir);
 }

--- a/contracts/splits/src/contract.rs
+++ b/contracts/splits/src/contract.rs
@@ -1,44 +1,52 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    coins, to_binary, BankMsg, Binary, Decimal, Deps, DepsMut, Env, MessageInfo, Response,
-    StdResult,
+    coins, to_binary, BankMsg, Binary, Decimal, Deps, DepsMut, Env, MessageInfo, Reply, Response,
+    StdResult, SubMsg, WasmMsg,
 };
 use cw2::set_contract_version;
 use cw4::{Cw4Contract, Member, MemberListResponse, MemberResponse};
+use cw4_group::msg::InstantiateMsg as Cw4GroupInstantiateMsg;
+use cw_utils::parse_reply_instantiate_data;
 use sg_std::NATIVE_DENOM;
 
 use crate::error::ContractError;
-use crate::msg::{ConfigResponse, ExecuteMsg, InstantiateMsg, QueryMsg};
-use crate::state::{Config, CONFIG};
+use crate::msg::{ExecuteMsg, GroupResponse, InstantiateMsg, QueryMsg};
+use crate::state::GROUP;
 
 // version info for migration info
 pub const CONTRACT_NAME: &str = "crates.io:sg-splits";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+const INIT_GROUP_REPLY_ID: u64 = 1;
+
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
     deps: DepsMut,
-    _env: Env,
+    env: Env,
     _info: MessageInfo,
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
-    let group_addr = Cw4Contract(deps.api.addr_validate(&msg.group_addr).map_err(|_| {
-        ContractError::InvalidGroup {
-            addr: msg.group_addr.clone(),
-        }
-    })?);
-    let weight = group_addr.total_weight(&deps.querier)?;
-    if weight == 0 {
-        return Err(ContractError::InvalidWeight { weight });
-    }
-
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
-    let cfg = Config { group_addr };
-    CONFIG.save(deps.storage, &cfg)?;
+    let splits_addr = env.contract.address;
 
-    Ok(Response::default())
+    // Create a group with an optional admin
+    let init_msg = Cw4GroupInstantiateMsg {
+        // TODO: change to optional admin
+        admin: Some(splits_addr.to_string()),
+        members: msg.members,
+    };
+    let wasm_msg = WasmMsg::Instantiate {
+        admin: Some(splits_addr.to_string()),
+        code_id: msg.group_code_id,
+        msg: to_binary(&init_msg)?,
+        funds: vec![],
+        label: "Splits-group".to_string(),
+    };
+    let submsg = SubMsg::reply_on_success(wasm_msg, INIT_GROUP_REPLY_ID);
+
+    Ok(Response::default().add_submessage(submsg))
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
@@ -58,19 +66,18 @@ pub fn execute_distribute(
     env: Env,
     info: MessageInfo,
 ) -> Result<Response, ContractError> {
-    let config = CONFIG.load(deps.storage)?;
+    let group = GROUP.load(deps.storage)?;
 
     // only a member can distribute funds
-    let weight = config
-        .group_addr
+    let weight = group
         .is_member(&deps.querier, &info.sender, None)?
         .ok_or(ContractError::Unauthorized {})?;
     if weight == 0 {
         return Err(ContractError::InvalidWeight { weight });
     }
 
-    let total_weight = config.group_addr.total_weight(&deps.querier)?;
-    let members = config.group_addr.list_members(&deps.querier, None, None)?;
+    let total_weight = group.total_weight(&deps.querier)?;
+    let members = group.list_members(&deps.querier, None, None)?;
 
     let funds = deps
         .querier
@@ -97,9 +104,38 @@ pub fn execute_distribute(
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
+pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractError> {
+    if msg.id != INIT_GROUP_REPLY_ID {
+        return Err(ContractError::InvalidReplyID {});
+    }
+
+    let reply = parse_reply_instantiate_data(msg);
+    match reply {
+        Ok(res) => {
+            let group_addr =
+                Cw4Contract(deps.api.addr_validate(&res.contract_address).map_err(|_| {
+                    ContractError::InvalidGroup {
+                        addr: res.contract_address.clone(),
+                    }
+                })?);
+
+            let weight = group_addr.total_weight(&deps.querier)?;
+            if weight == 0 {
+                return Err(ContractError::InvalidWeight { weight });
+            }
+
+            GROUP.save(deps.storage, &group_addr)?;
+
+            Ok(Response::default().add_attribute("action", "reply_on_success"))
+        }
+        Err(_) => Err(ContractError::ReplyOnSuccess {}),
+    }
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
-        QueryMsg::Config {} => to_binary(&query_config(deps)?),
+        QueryMsg::Group {} => to_binary(&query_group(deps)?),
         QueryMsg::ListMembers { start_after, limit } => {
             to_binary(&list_members(deps, start_after, limit)?)
         }
@@ -107,16 +143,15 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     }
 }
 
-fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
-    let config = CONFIG.load(deps.storage)?;
-
-    Ok(ConfigResponse { config })
+fn query_group(deps: Deps) -> StdResult<GroupResponse> {
+    let group = GROUP.load(deps.storage)?;
+    Ok(GroupResponse { group })
 }
 
 fn query_member(deps: Deps, member: String) -> StdResult<MemberResponse> {
-    let cfg = CONFIG.load(deps.storage)?;
+    let group = GROUP.load(deps.storage)?;
     let voter_addr = deps.api.addr_validate(&member)?;
-    let weight = cfg.group_addr.is_member(&deps.querier, &voter_addr, None)?;
+    let weight = group.is_member(&deps.querier, &voter_addr, None)?;
 
     Ok(MemberResponse { weight })
 }
@@ -126,9 +161,8 @@ fn list_members(
     start_after: Option<String>,
     limit: Option<u32>,
 ) -> StdResult<MemberListResponse> {
-    let cfg = CONFIG.load(deps.storage)?;
-    let members = cfg
-        .group_addr
+    let group = GROUP.load(deps.storage)?;
+    let members = group
         .list_members(&deps.querier, start_after, limit)?
         .into_iter()
         .map(|member| Member {

--- a/contracts/splits/src/error.rs
+++ b/contracts/splits/src/error.rs
@@ -12,6 +12,12 @@ pub enum ContractError {
     #[error("Contract has no funds")]
     NoFunds {},
 
+    #[error("Invalid reply ID")]
+    InvalidReplyID {},
+
+    #[error("Reply error")]
+    ReplyOnSuccess {},
+
     #[error("Group contract invalid address '{addr}'")]
     InvalidGroup { addr: String },
 

--- a/contracts/splits/src/msg.rs
+++ b/contracts/splits/src/msg.rs
@@ -1,12 +1,12 @@
+use cw4::{Cw4Contract, Member};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::state::Config;
-
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {
-    // this is the group contract that contains the member list
-    pub group_addr: String,
+    /// this is the code id for the group contract that contains the member list
+    pub group_code_id: u64,
+    pub members: Vec<Member>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -18,8 +18,8 @@ pub enum ExecuteMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
-    /// Returns the config
-    Config {},
+    /// Returns GroupResponse
+    Group {},
     /// Returns Member
     Member { address: String },
     /// Returns MemberListResponse
@@ -29,7 +29,7 @@ pub enum QueryMsg {
     },
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct ConfigResponse {
-    pub config: Config,
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct GroupResponse {
+    pub group: Cw4Contract,
 }

--- a/contracts/splits/src/msg.rs
+++ b/contracts/splits/src/msg.rs
@@ -7,6 +7,7 @@ pub struct InstantiateMsg {
     /// this is the code id for the group contract that contains the member list
     pub group_code_id: u64,
     pub members: Vec<Member>,
+    pub group_admin: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/contracts/splits/src/state.rs
+++ b/contracts/splits/src/state.rs
@@ -1,14 +1,7 @@
 use cw4::Cw4Contract;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
 use cw_storage_plus::Item;
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
-pub struct Config {
-    // Total weight and members are queried from this contract
-    pub group_addr: Cw4Contract,
-}
-
-// unique items
-pub const CONFIG: Item<Config> = Item::new("config");
+/// The group that holds splits members
+/// Total weight and voters are queried from this contract
+pub const GROUP: Item<Cw4Contract> = Item::new("group");

--- a/contracts/vending-minter/src/integration_tests.rs
+++ b/contracts/vending-minter/src/integration_tests.rs
@@ -80,12 +80,12 @@ pub fn contract_sg721() -> Box<dyn Contract<StargazeMsgWrapper>> {
 }
 
 pub fn contract_splits() -> Box<dyn Contract<StargazeMsgWrapper>> {
-    let contract = ContractWrapper::new_with_empty(
+    let contract = ContractWrapper::new(
         sg_splits::contract::execute,
         sg_splits::contract::instantiate,
         sg_splits::contract::query,
     )
-    .with_reply(crate::contract::reply);
+    .with_reply(sg_splits::contract::reply);
 
     Box::new(contract)
 }
@@ -288,10 +288,10 @@ fn instantiate_splits(app: &mut StargazeApp) -> Addr {
     let splits_id = app.store_code(contract_splits());
     let group_id = app.store_code(contract_group());
 
-    println!("splits_id: {}", splits_id);
     let msg = sg_splits::msg::InstantiateMsg {
         group_code_id: group_id,
         members: members(),
+        group_admin: None,
     };
     app.instantiate_contract(splits_id, Addr::unchecked(OWNER), &msg, &[], "splits", None)
         .unwrap()

--- a/packages/sg-multi-test/Cargo.toml
+++ b/packages/sg-multi-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sg-multi-test"
-version = "0.15.1"
+version = "0.16.0"
 edition = "2021"
 authors = ["Jorge Hernandez <jorge@publicawesome.com>"]
 description = "Integration test helpers for Stargaze custom contracts"

--- a/packages/sg-multi-test/src/multi.rs
+++ b/packages/sg-multi-test/src/multi.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Result as AnyResult};
 use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage};
 use cosmwasm_std::{
-    Addr, Api, Binary, BlockInfo, CustomQuery, Empty, Querier, QuerierResult, Storage,
+    Addr, Api, Binary, BlockInfo, Coin, CustomQuery, Empty, Querier, QuerierResult, Storage,
 };
 use cosmwasm_std::{BankMsg, OwnedDeps};
 use cw_multi_test::{
@@ -136,6 +136,19 @@ impl StargazeApp {
             BasicAppBuilder::<StargazeMsgWrapper, Empty>::new_custom()
                 .with_custom(StargazeModule {})
                 .build(|_, _, _| {}),
+        )
+    }
+
+    pub fn mock_app(init_funds: &[Coin], account: Addr) -> Self {
+        Self(
+            BasicAppBuilder::<StargazeMsgWrapper, Empty>::new_custom()
+                .with_custom(StargazeModule {})
+                .build(|router, _, storage| {
+                    router
+                        .bank
+                        .init_balance(storage, &account, init_funds.to_vec())
+                        .unwrap();
+                }),
         )
     }
 }


### PR DESCRIPTION
This creates the group within the splits contract instead of passing it in. This makes the frontend flow a lot easier as you don't have to 1) create a group, 2) search for the group, 3) create splits with the group address.

To discuss: who should be the admin of the group contract, if any? In this PR it's set to the sender.