### PR TITLE
add transaction index to the seed

### DIFF
--- a/contracts/vending-minter/src/contract.rs
+++ b/contracts/vending-minter/src/contract.rs
@@ -601,8 +601,14 @@ fn random_token_list(
     sender: Addr,
     mut tokens: Vec<u32>,
 ) -> Result<Vec<u32>, ContractError> {
-    let sha256 =
-        Sha256::digest(format!("{}{}{}", sender, env.block.height, tokens.len()).into_bytes());
+    let tx_index = if let Some(tx) = &env.transaction {
+        tx.index
+    } else {
+        0
+    };
+    let sha256 = Sha256::digest(
+        format!("{}{}{}{}", sender, env.block.height, tokens.len(), tx_index).into_bytes(),
+    );
     // Cut first 16 bytes from 32 byte value
     let randomness: [u8; 16] = sha256.to_vec()[0..16].try_into().unwrap();
     let mut rng = Xoshiro128PlusPlus::from_seed(randomness);
@@ -620,8 +626,14 @@ fn random_mintable_token_mapping(
     sender: Addr,
 ) -> Result<TokenPositionMapping, ContractError> {
     let num_tokens = MINTABLE_NUM_TOKENS.load(deps.storage)?;
-    let sha256 =
-        Sha256::digest(format!("{}{}{}", sender, num_tokens, env.block.height).into_bytes());
+    let tx_index = if let Some(tx) = &env.transaction {
+        tx.index
+    } else {
+        0
+    };
+    let sha256 = Sha256::digest(
+        format!("{}{}{}{}", sender, num_tokens, env.block.height, tx_index).into_bytes(),
+    );
     // Cut first 16 bytes from 32 byte value
     let randomness: [u8; 16] = sha256.to_vec()[0..16].try_into().unwrap();
 

--- a/contracts/vending-minter/src/integration_tests.rs
+++ b/contracts/vending-minter/src/integration_tests.rs
@@ -509,7 +509,7 @@ fn happy_path() {
     // Check NFT owned by buyer
     // Random mint token_id 1
     let query_owner_msg = Cw721QueryMsg::OwnerOf {
-        token_id: String::from("1"),
+        token_id: String::from("2"),
         include_expired: None,
     };
 


### PR DESCRIPTION
Previous version of CosmWasm was not providing the right tx index from the environment, this has been fixed in 0.29 and cosmwasm 1.1.

This PRs adds back the tx index which will depend on how many txs land on the same block.