### PR TITLE
Use Launchpad Whitelist Generic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,7 @@ dependencies = [
  "thiserror",
  "vending-factory",
  "vending-minter",
- "whitelist-generic 0.12.0",
+ "whitelist-generic",
 ]
 
 [[package]]
@@ -2031,18 +2031,6 @@ dependencies = [
  "schemars",
  "serde",
  "sg-std 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "sg-name-minter"
-version = "0.12.0"
-source = "git+https://github.com/public-awesome/names.git?rev=91256f9ccfcec66fa8d4c2040acc9e10415c711a#91256f9ccfcec66fa8d4c2040acc9e10415c711a"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-controllers",
- "schemars",
- "serde",
 ]
 
 [[package]]
@@ -2123,17 +2111,6 @@ name = "sg-whitelist-basic"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf0670b0de4489224faa3c18ceb28af7251441118473f454110739a69df587b9"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "sg-whitelist-basic"
-version = "0.12.0"
-source = "git+https://github.com/public-awesome/names.git?rev=91256f9ccfcec66fa8d4c2040acc9e10415c711a#91256f9ccfcec66fa8d4c2040acc9e10415c711a"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2741,25 +2718,6 @@ dependencies = [
 
 [[package]]
 name = "whitelist-generic"
-version = "0.12.0"
-source = "git+https://github.com/public-awesome/names.git?rev=91256f9ccfcec66fa8d4c2040acc9e10415c711a#91256f9ccfcec66fa8d4c2040acc9e10415c711a"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-controllers",
- "cw-storage-plus",
- "cw-utils",
- "cw2",
- "schemars",
- "serde",
- "sg-name-minter",
- "sg-std 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sg-whitelist-basic 0.12.0 (git+https://github.com/public-awesome/names.git?rev=91256f9ccfcec66fa8d4c2040acc9e10415c711a)",
- "thiserror",
-]
-
-[[package]]
-name = "whitelist-generic"
 version = "0.21.1"
 dependencies = [
  "cosmwasm-schema",
@@ -2773,7 +2731,7 @@ dependencies = [
  "serde",
  "sg-multi-test 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sg-std 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sg-whitelist-basic 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sg-whitelist-basic",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ sha2 = { version = "0.10.2", default-features = false }
 rand_core = { version = "0.6.4", default-features = false }
 vending-factory = { version = "0.21.1", path = "contracts/vending-factory" }
 vending-minter = { version = "0.21.1", path = "contracts/vending-minter" }
+whitelist-generic = { version = "0.21.1", path = "contracts/whitelist-generic" }
 sg-whitelist-basic = { version = "0.12.0" }
 
 [profile.release.package.sg721]
@@ -98,6 +99,10 @@ codegen-units = 1
 incremental = false
 
 [profile.release.package.sg-splits]
+codegen-units = 1
+incremental = false
+
+[profile.release.package.whitelist-generic]
 codegen-units = 1
 incremental = false
 

--- a/contracts/sg-eth-airdrop/Cargo.toml
+++ b/contracts/sg-eth-airdrop/Cargo.toml
@@ -61,10 +61,8 @@ schemars = { workspace = true }
 serde = { workspace = true }
 sg-std = { workspace = true }
 thiserror = { workspace = true }
-whitelist-generic = { git = "https://github.com/public-awesome/names.git", rev = "91256f9ccfcec66fa8d4c2040acc9e10415c711a", features = [
-  "library",
-] }
 vending-minter = { workspace = true, features = ["library"] }
+whitelist-generic = { workspace = true, features = ["library"] }
 
 [dev-dependencies]
 async-std = "1.12.0"

--- a/contracts/sg-eth-airdrop/src/helpers/build_msg.rs
+++ b/contracts/sg-eth-airdrop/src/helpers/build_msg.rs
@@ -60,17 +60,6 @@ pub fn build_remove_eth_eligible_msg(
     WhitelistGenericContract(deps.api.addr_validate(&whitelist_address)?).call(execute_msg)
 }
 
-pub fn build_update_minter_address_msg(
-    deps: DepsMut,
-    whitelist_address: String,
-    minter_address: String,
-) -> StdResult<CosmosMsg> {
-    let execute_msg = WGExecuteMsg::UpdateMinterContract {
-        minter_contract: minter_address,
-    };
-    WhitelistGenericContract(deps.api.addr_validate(&whitelist_address)?).call(execute_msg)
-}
-
 pub fn build_add_member_minter_msg(
     deps: DepsMut,
     wallet_address: Addr,


### PR DESCRIPTION
We were using the generic whitelist from names before, then I implemented a version in Launchpad. 

This PR is just to plug in the generic whitelist to the airdrop contract.  