### PR TITLE
Use process addresses for whitelist

### DIFF
--- a/contracts/sg-eth-airdrop/schema/instantiate_msg.json
+++ b/contracts/sg-eth-airdrop/schema/instantiate_msg.json
@@ -8,6 +8,7 @@
     "airdrop_amount",
     "claim_msg_plaintext",
     "minter_address",
+    "per_address_limit",
     "whitelist_code_id"
   ],
   "properties": {
@@ -30,6 +31,11 @@
     },
     "minter_address": {
       "$ref": "#/definitions/Addr"
+    },
+    "per_address_limit": {
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0.0
     },
     "whitelist_code_id": {
       "type": "integer",

--- a/contracts/sg-eth-airdrop/src/helpers/build_msg.rs
+++ b/contracts/sg-eth-airdrop/src/helpers/build_msg.rs
@@ -21,7 +21,7 @@ pub fn build_whitelist_instantiate_msg(
     let whitelist_instantiate_msg = WGInstantiateMsg {
         addresses: msg.addresses,
         mint_discount_bps: Some(0),
-        per_address_limit: 1,
+        per_address_limit: msg.per_address_limit,
     };
     let wasm_msg = WasmMsg::Instantiate {
         code_id: msg.whitelist_code_id,

--- a/contracts/sg-eth-airdrop/src/helpers/build_msg.rs
+++ b/contracts/sg-eth-airdrop/src/helpers/build_msg.rs
@@ -2,7 +2,7 @@ use crate::constants::{GENERIC_WHITELIST_LABEL, INIT_WHITELIST_REPLY_ID, NATIVE_
 use crate::contract::get_collection_whitelist;
 #[cfg(not(feature = "library"))]
 use crate::msg::InstantiateMsg;
-use crate::responses::get_remove_eligible_eth_response;
+use crate::responses::get_process_eligible_eth_response;
 use crate::ContractError;
 use cosmwasm_std::{coins, Addr, BankMsg};
 use cosmwasm_std::{to_binary, DepsMut, Env, MessageInfo, StdResult, WasmMsg};
@@ -49,15 +49,13 @@ pub fn build_add_eth_eligible_msg(
     WhitelistGenericContract(deps.api.addr_validate(&whitelist_address)?).call(execute_msg)
 }
 
-pub fn build_remove_eth_eligible_msg(
+pub fn build_process_eth_eligible_msg(
     deps: &DepsMut,
     eth_address: String,
     whitelist_address: String,
 ) -> StdResult<CosmosMsg> {
-    let execute_msg = WGExecuteMsg::RemoveAddresses {
-        addresses: vec![eth_address],
-    };
-    WhitelistGenericContract(deps.api.addr_validate(&whitelist_address)?).call(execute_msg)
+    WhitelistGenericContract(deps.api.addr_validate(&whitelist_address)?)
+        .process_address(&eth_address)
 }
 
 pub fn build_add_member_minter_msg(
@@ -78,7 +76,7 @@ pub fn build_messages_for_claim_and_whitelist_add(
     eth_address: String,
     airdrop_amount: u128,
 ) -> Result<Response, ContractError> {
-    let mut res = get_remove_eligible_eth_response(&deps, eth_address).unwrap();
+    let mut res = get_process_eligible_eth_response(&deps, eth_address).unwrap();
     res = res.add_submessage(build_bank_message(info.clone(), airdrop_amount));
     let collection_whitelist = get_collection_whitelist(&deps)?;
     let res = res

--- a/contracts/sg-eth-airdrop/src/helpers/responses.rs
+++ b/contracts/sg-eth-airdrop/src/helpers/responses.rs
@@ -3,7 +3,7 @@ use crate::state::CONFIG;
 use cosmwasm_std::{DepsMut, MessageInfo};
 use sg_std::Response;
 
-use crate::build_msg::{build_add_eth_eligible_msg, build_remove_eth_eligible_msg};
+use crate::build_msg::{build_add_eth_eligible_msg, build_process_eth_eligible_msg};
 
 pub fn get_add_eligible_eth_response(
     deps: DepsMut,
@@ -26,7 +26,7 @@ pub fn get_add_eligible_eth_response(
     Ok(res)
 }
 
-pub fn get_remove_eligible_eth_response(
+pub fn get_process_eligible_eth_response(
     deps: &DepsMut,
     eth_address: String,
 ) -> Result<Response, ContractError> {
@@ -37,7 +37,7 @@ pub fn get_remove_eligible_eth_response(
     };
 
     let mut res = Response::new();
-    let remove_eth_msg = build_remove_eth_eligible_msg(deps, eth_address, whitelist_address)?;
+    let remove_eth_msg = build_process_eth_eligible_msg(deps, eth_address, whitelist_address)?;
     res = res.add_message(remove_eth_msg);
     Ok(res)
 }

--- a/contracts/sg-eth-airdrop/src/msg.rs
+++ b/contracts/sg-eth-airdrop/src/msg.rs
@@ -11,6 +11,7 @@ pub struct InstantiateMsg {
     pub addresses: Vec<String>,
     pub whitelist_code_id: u64,
     pub minter_address: Addr,
+    pub per_address_limit: u32,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]

--- a/contracts/sg-eth-airdrop/src/testing/lib.rs
+++ b/contracts/sg-eth-airdrop/src/testing/lib.rs
@@ -18,6 +18,9 @@ mod mock_minter;
 #[path = "./setup/mock_whitelist.rs"]
 mod mock_whitelist;
 
+#[path = "./setup/test_msgs.rs"]
+mod test_msgs;
+
 #[path = "./tests/collection_whitelist_helpers.rs"]
 pub mod collection_whitelist_helpers;
 #[cfg(test)]

--- a/contracts/sg-eth-airdrop/src/testing/lib.rs
+++ b/contracts/sg-eth-airdrop/src/testing/lib.rs
@@ -17,7 +17,6 @@ mod setup_signatures;
 mod mock_minter;
 #[path = "./setup/mock_whitelist.rs"]
 mod mock_whitelist;
-
 #[path = "./setup/test_msgs.rs"]
 mod test_msgs;
 

--- a/contracts/sg-eth-airdrop/src/testing/setup/setup_contracts.rs
+++ b/contracts/sg-eth-airdrop/src/testing/setup/setup_contracts.rs
@@ -94,13 +94,7 @@ pub fn whitelist_generic_contract() -> Box<dyn Contract<StargazeMsgWrapper>> {
 }
 
 pub fn instantiate_contract(
-    // addresses: Vec<String>,
-    // funds_amount: u128,
-    // expected_airdrop_contract_id: u64,
-    // minter_address: Addr,
-    // admin_account: Addr,
-    // app: &mut StargazeApp,
-    params: InstantiateParams,
+    params: InstantiateParams
 ) {
     let addresses = params.addresses;
     let minter_address = params.minter_address;

--- a/contracts/sg-eth-airdrop/src/testing/setup/setup_contracts.rs
+++ b/contracts/sg-eth-airdrop/src/testing/setup/setup_contracts.rs
@@ -13,6 +13,8 @@ extern crate whitelist_generic;
 use crate::tests_folder::claim_constants::{CONTRACT_CONFIG_PLAINTEXT, NATIVE_DENOM, OWNER};
 use crate::tests_folder::{mock_minter, mock_whitelist};
 
+use super::test_msgs::InstantiateParams;
+
 pub fn custom_mock_app() -> StargazeApp {
     StargazeApp::default()
 }
@@ -92,25 +94,34 @@ pub fn whitelist_generic_contract() -> Box<dyn Contract<StargazeMsgWrapper>> {
 }
 
 pub fn instantiate_contract(
-    addresses: Vec<String>,
-    funds_amount: u128,
-    expected_airdrop_contract_id: u64,
-    minter_address: Addr,
-    admin_account: Addr,
-    app: &mut StargazeApp,
+    // addresses: Vec<String>,
+    // funds_amount: u128,
+    // expected_airdrop_contract_id: u64,
+    // minter_address: Addr,
+    // admin_account: Addr,
+    // app: &mut StargazeApp,
+    params: InstantiateParams,
 ) {
-    app.sudo(SudoMsg::Bank({
-        BankSudo::Mint {
-            to_address: admin_account.to_string(),
-            amount: coins(funds_amount, NATIVE_DENOM),
-        }
-    }))
-    .map_err(|err| println!("{:?}", err))
-    .ok();
+    let addresses = params.addresses;
+    let minter_address = params.minter_address;
+    let admin_account = params.admin_account;
+    let funds_amount = params.funds_amount;
 
-    let sg_eth_id = app.store_code(contract());
-    let whitelist_code_id = app.store_code(whitelist_generic_contract());
-    assert_eq!(sg_eth_id, expected_airdrop_contract_id);
+    params
+        .app
+        .sudo(SudoMsg::Bank({
+            BankSudo::Mint {
+                to_address: admin_account.to_string(),
+                amount: coins(params.funds_amount, NATIVE_DENOM),
+            }
+        }))
+        .map_err(|err| println!("{:?}", err))
+        .ok();
+
+    let sg_eth_id = params.app.store_code(contract());
+    let whitelist_code_id = params.app.store_code(whitelist_generic_contract());
+    assert_eq!(sg_eth_id, params.expected_airdrop_contract_id);
+
     let msg: InstantiateMsg = InstantiateMsg {
         admin: Addr::unchecked(OWNER),
         claim_msg_plaintext: Addr::unchecked(CONTRACT_CONFIG_PLAINTEXT).into_string(),
@@ -118,8 +129,10 @@ pub fn instantiate_contract(
         addresses,
         whitelist_code_id,
         minter_address,
+        per_address_limit: 1,
     };
-    let _ = app
+    let _ = params
+        .app
         .instantiate_contract(
             sg_eth_id,
             Addr::unchecked(admin_account.clone()),
@@ -129,25 +142,6 @@ pub fn instantiate_contract(
             Some(Addr::unchecked(admin_account).to_string()),
         )
         .unwrap();
-}
-
-pub fn instantiate_contract_get_app(
-    addresses: Vec<String>,
-    funds_amount: u128,
-    expected_airdrop_contract_id: u64,
-    minter_address: Addr,
-) -> StargazeApp {
-    let mut app = custom_mock_app();
-
-    instantiate_contract(
-        addresses,
-        funds_amount,
-        expected_airdrop_contract_id,
-        minter_address,
-        Addr::unchecked(OWNER),
-        &mut app,
-    );
-    app
 }
 
 pub fn execute_contract_with_msg(
@@ -160,4 +154,16 @@ pub fn execute_contract_with_msg(
         .execute_contract(user, target_address, &msg, &[])
         .unwrap();
     Ok(result)
+}
+
+pub fn execute_contract_error_with_msg(
+    msg: ExecuteMsg,
+    app: &mut StargazeApp,
+    user: Addr,
+    target_address: Addr,
+) -> String {
+    let result = app
+        .execute_contract(user, target_address, &msg, &[])
+        .unwrap_err();
+    result.root_cause().to_string()
 }

--- a/contracts/sg-eth-airdrop/src/testing/setup/setup_contracts.rs
+++ b/contracts/sg-eth-airdrop/src/testing/setup/setup_contracts.rs
@@ -10,10 +10,9 @@ use crate::tests_folder::collection_constants::WHITELIST_AMOUNT;
 use eyre::Result;
 
 extern crate whitelist_generic;
+use super::test_msgs::InstantiateParams;
 use crate::tests_folder::claim_constants::{CONTRACT_CONFIG_PLAINTEXT, NATIVE_DENOM, OWNER};
 use crate::tests_folder::{mock_minter, mock_whitelist};
-
-use super::test_msgs::InstantiateParams;
 
 pub fn custom_mock_app() -> StargazeApp {
     StargazeApp::default()
@@ -93,13 +92,12 @@ pub fn whitelist_generic_contract() -> Box<dyn Contract<StargazeMsgWrapper>> {
     Box::new(contract)
 }
 
-pub fn instantiate_contract(
-    params: InstantiateParams
-) {
+pub fn instantiate_contract(params: InstantiateParams) {
     let addresses = params.addresses;
     let minter_address = params.minter_address;
     let admin_account = params.admin_account;
     let funds_amount = params.funds_amount;
+    let per_address_limit = params.per_address_limit;
 
     params
         .app
@@ -123,7 +121,7 @@ pub fn instantiate_contract(
         addresses,
         whitelist_code_id,
         minter_address,
-        per_address_limit: 1,
+        per_address_limit,
     };
     let _ = params
         .app

--- a/contracts/sg-eth-airdrop/src/testing/setup/setup_signatures.rs
+++ b/contracts/sg-eth-airdrop/src/testing/setup/setup_signatures.rs
@@ -1,8 +1,7 @@
+use crate::tests_folder::claim_constants::CONTRACT_CONFIG_PLAINTEXT;
 use async_std::task;
 use ethers_core::{k256::ecdsa::SigningKey, rand::thread_rng, types::H160};
 use ethers_signers::{LocalWallet, Signer, Wallet, WalletError};
-
-use crate::tests_folder::claim_constants::CONTRACT_CONFIG_PLAINTEXT;
 
 pub async fn get_signature(
     wallet: Wallet<SigningKey>,

--- a/contracts/sg-eth-airdrop/src/testing/setup/test_msgs.rs
+++ b/contracts/sg-eth-airdrop/src/testing/setup/test_msgs.rs
@@ -8,5 +8,5 @@ pub struct InstantiateParams<'a> {
     pub minter_address: Addr,
     pub admin_account: Addr,
     pub app: &'a mut StargazeApp,
-    pub per_address_limit: u64,
+    pub per_address_limit: u32,
 }

--- a/contracts/sg-eth-airdrop/src/testing/setup/test_msgs.rs
+++ b/contracts/sg-eth-airdrop/src/testing/setup/test_msgs.rs
@@ -1,0 +1,12 @@
+use cosmwasm_std::Addr;
+use sg_multi_test::StargazeApp;
+
+pub struct InstantiateParams<'a> {
+    pub addresses: Vec<String>,
+    pub funds_amount: u128,
+    pub expected_airdrop_contract_id: u64,
+    pub minter_address: Addr,
+    pub admin_account: Addr,
+    pub app: &'a mut StargazeApp,
+    pub per_address_limit: u64,
+}

--- a/contracts/sg-eth-airdrop/src/testing/tests/test_claim.rs
+++ b/contracts/sg-eth-airdrop/src/testing/tests/test_claim.rs
@@ -482,7 +482,7 @@ fn test_two_claims_allowed_success() {
 
     let params = InstantiateParams {
         addresses: vec![eth_addr_str.clone()],
-        funds_amount: WHITELIST_AMOUNT,
+        funds_amount: WHITELIST_AMOUNT * 2,
         expected_airdrop_contract_id: 4,
         minter_address: minter_addr,
         admin_account: Addr::unchecked(OWNER),
@@ -496,6 +496,28 @@ fn test_two_claims_allowed_success() {
         .query_all_balances(stargaze_wallet_01.clone())
         .unwrap();
     assert_eq!(balances, []);
+
+    let claim_message = ExecuteMsg::ClaimAirdrop {
+        eth_address: eth_addr_str.clone(),
+        eth_sig: eth_sig_str.clone(),
+    };
+    let _ = execute_contract_with_msg(
+        claim_message,
+        &mut app,
+        stargaze_wallet_01.clone(),
+        airdrop_contract.clone(),
+    )
+    .unwrap();
+
+    let balances = app
+        .wrap()
+        .query_all_balances(stargaze_wallet_01.clone())
+        .unwrap();
+    let expected_balance = [Coin {
+        denom: NATIVE_DENOM.to_string(),
+        amount: Uint128::new(WHITELIST_AMOUNT),
+    }];
+    assert_eq!(balances, expected_balance);
 
     let claim_message = ExecuteMsg::ClaimAirdrop {
         eth_address: eth_addr_str,
@@ -512,7 +534,7 @@ fn test_two_claims_allowed_success() {
     let balances = app.wrap().query_all_balances(stargaze_wallet_01).unwrap();
     let expected_balance = [Coin {
         denom: NATIVE_DENOM.to_string(),
-        amount: Uint128::new(WHITELIST_AMOUNT),
+        amount: Uint128::new(2 * WHITELIST_AMOUNT),
     }];
     assert_eq!(balances, expected_balance)
 }

--- a/contracts/sg-eth-airdrop/src/testing/tests/test_claim.rs
+++ b/contracts/sg-eth-airdrop/src/testing/tests/test_claim.rs
@@ -11,15 +11,29 @@ use crate::tests_folder::claim_constants::{
     STARGAZE_WALLET_02,
 };
 use crate::tests_folder::setup_contracts::{
-    custom_mock_app, execute_contract_with_msg, instantiate_contract, instantiate_contract_get_app,
+    custom_mock_app, execute_contract_error_with_msg, execute_contract_with_msg,
+    instantiate_contract,
 };
 use crate::tests_folder::setup_minter::configure_mock_minter_with_mock_whitelist;
 use crate::tests_folder::setup_signatures::{get_msg_plaintext, get_signature, get_wallet_and_sig};
+use crate::tests_folder::test_msgs::InstantiateParams;
 
 #[test]
 fn test_instantiate() {
+    let mut app = custom_mock_app();
     let minter_address = Addr::unchecked("contract1");
-    instantiate_contract_get_app(vec![], 10000, 1, minter_address);
+    let claim_plaintext = &get_msg_plaintext(STARGAZE_WALLET_01.to_string());
+    let (_, _, _, eth_addr_str) = get_wallet_and_sig(claim_plaintext.clone());
+    let params = InstantiateParams {
+        addresses: vec![eth_addr_str],
+        funds_amount: WHITELIST_AMOUNT,
+        expected_airdrop_contract_id: 1,
+        minter_address,
+        admin_account: Addr::unchecked(OWNER),
+        app: &mut app,
+        per_address_limit: 1,
+    };
+    instantiate_contract(params);
 }
 
 #[test]
@@ -31,14 +45,16 @@ fn test_valid_eth_sig_claim() {
     let minter_addr = Addr::unchecked(MOCK_MINTER_ADDR_STR);
     let airdrop_contract = Addr::unchecked(MOCK_AIRDROP_ADDR_STR);
 
-    instantiate_contract(
-        vec![eth_addr_str.clone()],
-        WHITELIST_AMOUNT,
-        4,
-        minter_addr.clone(),
-        Addr::unchecked(OWNER),
-        &mut app,
-    );
+    let params = InstantiateParams {
+        addresses: vec![eth_addr_str.clone()],
+        funds_amount: WHITELIST_AMOUNT,
+        expected_airdrop_contract_id: 4,
+        minter_address: minter_addr.clone(),
+        admin_account: Addr::unchecked(OWNER),
+        app: &mut app,
+        per_address_limit: 1,
+    };
+    instantiate_contract(params);
 
     let claim_message = ExecuteMsg::ClaimAirdrop {
         eth_address: eth_addr_str,
@@ -90,14 +106,16 @@ fn test_invalid_eth_sig_claim() {
     let minter_addr = Addr::unchecked(MOCK_MINTER_ADDR_STR);
     let airdrop_contract = Addr::unchecked(MOCK_AIRDROP_ADDR_STR);
 
-    instantiate_contract(
-        vec![eth_addr_str.clone()],
-        WHITELIST_AMOUNT,
-        4,
-        minter_addr.clone(),
-        Addr::unchecked(OWNER),
-        &mut app,
-    );
+    let params = InstantiateParams {
+        addresses: vec![eth_addr_str.clone()],
+        funds_amount: WHITELIST_AMOUNT,
+        expected_airdrop_contract_id: 4,
+        minter_address: minter_addr.clone(),
+        admin_account: Addr::unchecked(OWNER),
+        app: &mut app,
+        per_address_limit: 1,
+    };
+    instantiate_contract(params);
 
     let claim_message = ExecuteMsg::ClaimAirdrop {
         eth_address: eth_addr_str,
@@ -147,14 +165,16 @@ fn test_can_not_claim_twice() {
     let minter_addr = Addr::unchecked(MOCK_MINTER_ADDR_STR);
     let airdrop_contract = Addr::unchecked(MOCK_AIRDROP_ADDR_STR);
 
-    instantiate_contract(
-        vec![eth_addr_str.clone()],
-        WHITELIST_AMOUNT,
-        4,
-        minter_addr.clone(),
-        Addr::unchecked(OWNER),
-        &mut app,
-    );
+    let params = InstantiateParams {
+        addresses: vec![eth_addr_str.clone()],
+        funds_amount: WHITELIST_AMOUNT,
+        expected_airdrop_contract_id: 4,
+        minter_address: minter_addr.clone(),
+        admin_account: Addr::unchecked(OWNER),
+        app: &mut app,
+        per_address_limit: 1,
+    };
+    instantiate_contract(params);
 
     let claim_message = ExecuteMsg::ClaimAirdrop {
         eth_address: eth_addr_str,
@@ -192,36 +212,13 @@ fn test_can_not_claim_twice() {
         },
     ];
     assert_eq!(res.events[1].attributes, expected_attributes);
-    let res = execute_contract_with_msg(
+    let res = execute_contract_error_with_msg(
         claim_message,
         &mut app,
         stargaze_wallet_01,
-        airdrop_contract.clone(),
-    )
-    .unwrap();
-    let expected_attributes = [
-        Attribute {
-            key: "_contract_addr".to_string(),
-            value: airdrop_contract.to_string(),
-        },
-        Attribute {
-            key: "claimed_amount".to_string(),
-            value: "0".to_string(),
-        },
-        Attribute {
-            key: "valid_eth_sig".to_string(),
-            value: "true".to_string(),
-        },
-        Attribute {
-            key: "eligible_at_request".to_string(),
-            value: "false".to_string(),
-        },
-        Attribute {
-            key: "minter_address".to_string(),
-            value: minter_addr.to_string(),
-        },
-    ];
-    assert_eq!(res.events[1].attributes, expected_attributes);
+        airdrop_contract,
+    );
+    assert_eq!(res, "OverPerAddressLimit");
 }
 
 #[test]
@@ -236,14 +233,16 @@ fn test_claim_one_valid_airdrop() {
     let minter_addr = Addr::unchecked(MOCK_MINTER_ADDR_STR);
     let airdrop_contract = Addr::unchecked(MOCK_AIRDROP_ADDR_STR);
 
-    instantiate_contract(
-        vec![eth_addr_str.clone()],
-        WHITELIST_AMOUNT,
-        4,
-        minter_addr,
-        Addr::unchecked(OWNER),
-        &mut app,
-    );
+    let params = InstantiateParams {
+        addresses: vec![eth_addr_str.clone()],
+        funds_amount: WHITELIST_AMOUNT,
+        expected_airdrop_contract_id: 4,
+        minter_address: minter_addr,
+        admin_account: Addr::unchecked(OWNER),
+        app: &mut app,
+        per_address_limit: 1,
+    };
+    instantiate_contract(params);
 
     let balances = app
         .wrap()
@@ -283,14 +282,16 @@ fn test_claim_twice_receive_funds_once() {
     let minter_addr = Addr::unchecked(MOCK_MINTER_ADDR_STR);
     let airdrop_contract = Addr::unchecked(MOCK_AIRDROP_ADDR_STR);
 
-    instantiate_contract(
-        vec![eth_addr_str.clone()],
-        WHITELIST_AMOUNT,
-        4,
-        minter_addr,
-        Addr::unchecked(OWNER),
-        &mut app,
-    );
+    let params = InstantiateParams {
+        addresses: vec![eth_addr_str.clone()],
+        funds_amount: WHITELIST_AMOUNT,
+        expected_airdrop_contract_id: 4,
+        minter_address: minter_addr,
+        admin_account: Addr::unchecked(OWNER),
+        app: &mut app,
+        per_address_limit: 1,
+    };
+    instantiate_contract(params);
     let balances = app
         .wrap()
         .query_all_balances(stargaze_wallet_01.clone())
@@ -318,13 +319,13 @@ fn test_claim_twice_receive_funds_once() {
         amount: Uint128::new(WHITELIST_AMOUNT),
     }];
     assert_eq!(balances, expected_balance);
-    let _ = execute_contract_with_msg(
+    let res = execute_contract_error_with_msg(
         claim_message,
         &mut app,
         stargaze_wallet_01.clone(),
         airdrop_contract,
-    )
-    .unwrap();
+    );
+    assert_eq!(res, "OverPerAddressLimit");
 
     let balances = app.wrap().query_all_balances(stargaze_wallet_01).unwrap();
     let expected_balance = [Coin {
@@ -344,15 +345,16 @@ fn test_ineligible_does_not_receive_funds() {
     let minter_addr = Addr::unchecked(MOCK_MINTER_ADDR_STR);
     let airdrop_contract = Addr::unchecked(MOCK_AIRDROP_ADDR_STR);
 
-    instantiate_contract(
-        vec![eth_addr_str],
-        WHITELIST_AMOUNT,
-        4,
-        minter_addr,
-        Addr::unchecked(OWNER),
-        &mut app,
-    );
-
+    let params = InstantiateParams {
+        addresses: vec![eth_addr_str],
+        funds_amount: WHITELIST_AMOUNT,
+        expected_airdrop_contract_id: 4,
+        minter_address: minter_addr,
+        admin_account: Addr::unchecked(OWNER),
+        app: &mut app,
+        per_address_limit: 1,
+    };
+    instantiate_contract(params);
     let stargaze_wallet_02 = Addr::unchecked(STARGAZE_WALLET_02);
     let balances = app
         .wrap()
@@ -398,14 +400,16 @@ fn test_one_eth_claim_two_stargaze_addresses_invalid() {
     let minter_addr = Addr::unchecked(MOCK_MINTER_ADDR_STR);
     let airdrop_contract = Addr::unchecked(MOCK_AIRDROP_ADDR_STR);
 
-    instantiate_contract(
-        vec![eth_addr_str_1.clone()],
-        WHITELIST_AMOUNT,
-        4,
-        minter_addr.clone(),
-        Addr::unchecked(OWNER),
-        &mut app,
-    );
+    let params = InstantiateParams {
+        addresses: vec![eth_addr_str_1.clone()],
+        funds_amount: WHITELIST_AMOUNT,
+        expected_airdrop_contract_id: 4,
+        minter_address: minter_addr.clone(),
+        admin_account: Addr::unchecked(OWNER),
+        app: &mut app,
+        per_address_limit: 1,
+    };
+    instantiate_contract(params);
 
     // claim with eth address 1, stargaze wallet 1
     let claim_message = ExecuteMsg::ClaimAirdrop {
@@ -455,35 +459,60 @@ fn test_one_eth_claim_two_stargaze_addresses_invalid() {
         eth_sig: eth_sig_str_2,
     };
 
-    let res_2 = execute_contract_with_msg(
+    let res_2 = execute_contract_error_with_msg(
         claim_message,
         &mut app,
         stargaze_wallet_02,
-        airdrop_contract.clone(),
+        airdrop_contract,
+    );
+    assert_eq!(res_2, "OverPerAddressLimit")
+}
+
+#[test]
+fn test_two_claims_allowed_success() {
+    let claim_plaintext = &get_msg_plaintext(STARGAZE_WALLET_01.to_string());
+    let (_, eth_sig_str, _, eth_addr_str) = get_wallet_and_sig(claim_plaintext.clone());
+
+    let stargaze_wallet_01 = Addr::unchecked(STARGAZE_WALLET_01);
+
+    let mut app = custom_mock_app();
+    configure_mock_minter_with_mock_whitelist(&mut app);
+    let minter_addr = Addr::unchecked(MOCK_MINTER_ADDR_STR);
+    let airdrop_contract = Addr::unchecked(MOCK_AIRDROP_ADDR_STR);
+
+    let params = InstantiateParams {
+        addresses: vec![eth_addr_str.clone()],
+        funds_amount: WHITELIST_AMOUNT,
+        expected_airdrop_contract_id: 4,
+        minter_address: minter_addr,
+        admin_account: Addr::unchecked(OWNER),
+        app: &mut app,
+        per_address_limit: 2,
+    };
+    instantiate_contract(params);
+
+    let balances = app
+        .wrap()
+        .query_all_balances(stargaze_wallet_01.clone())
+        .unwrap();
+    assert_eq!(balances, []);
+
+    let claim_message = ExecuteMsg::ClaimAirdrop {
+        eth_address: eth_addr_str,
+        eth_sig: eth_sig_str,
+    };
+    let _ = execute_contract_with_msg(
+        claim_message,
+        &mut app,
+        stargaze_wallet_01.clone(),
+        airdrop_contract,
     )
     .unwrap();
 
-    let expected_attributes = [
-        Attribute {
-            key: "_contract_addr".to_string(),
-            value: airdrop_contract.to_string(),
-        },
-        Attribute {
-            key: "claimed_amount".to_string(),
-            value: "0".to_string(),
-        },
-        Attribute {
-            key: "valid_eth_sig".to_string(),
-            value: "true".to_string(),
-        },
-        Attribute {
-            key: "eligible_at_request".to_string(),
-            value: "false".to_string(),
-        },
-        Attribute {
-            key: "minter_address".to_string(),
-            value: minter_addr.to_string(),
-        },
-    ];
-    assert_eq!(res_2.events[1].attributes, expected_attributes);
+    let balances = app.wrap().query_all_balances(stargaze_wallet_01).unwrap();
+    let expected_balance = [Coin {
+        denom: NATIVE_DENOM.to_string(),
+        amount: Uint128::new(WHITELIST_AMOUNT),
+    }];
+    assert_eq!(balances, expected_balance)
 }

--- a/contracts/sg-eth-airdrop/src/testing/tests/test_collection_whitelist.rs
+++ b/contracts/sg-eth-airdrop/src/testing/tests/test_collection_whitelist.rs
@@ -11,7 +11,7 @@ use crate::tests_folder::setup_contracts::instantiate_contract;
 use crate::tests_folder::setup_contracts::{custom_mock_app, execute_contract_with_msg};
 use crate::tests_folder::setup_minter::configure_minter_with_whitelist;
 use crate::tests_folder::setup_signatures::{get_msg_plaintext, get_wallet_and_sig};
-
+use crate::tests_folder::test_msgs::InstantiateParams;
 extern crate whitelist_generic;
 
 #[test]
@@ -24,14 +24,16 @@ fn test_set_minter_contract() {
 
     let first_minter = Addr::unchecked("first_minter");
     let contract_admin = Addr::unchecked(config.admin);
-    instantiate_contract(
-        vec![eth_addr_str],
-        10000,
-        5,
-        first_minter.clone(),
-        contract_admin.clone(),
-        &mut app,
-    );
+    let params = InstantiateParams {
+        addresses: vec![eth_addr_str],
+        funds_amount: WHITELIST_AMOUNT,
+        expected_airdrop_contract_id: 5,
+        minter_address: first_minter.clone(),
+        admin_account: contract_admin.clone(),
+        app: &mut app,
+        per_address_limit: 1,
+    };
+    instantiate_contract(params);
     let airdrop_contract = Addr::unchecked(AIRDROP_ADDR_STR);
     let query_msg = QueryMsg::GetMinter {};
     let result: Addr = app
@@ -65,15 +67,17 @@ fn test_claim_added_to_minter_whitelist() {
     let (_, eth_sig_str, _, eth_addr_str) = get_wallet_and_sig(claim_plaintext.clone());
 
     let airdrop_contract = Addr::unchecked(AIRDROP_ADDR_STR);
+    let params = InstantiateParams {
+        addresses: vec![eth_addr_str.clone()],
+        funds_amount: WHITELIST_AMOUNT,
+        expected_airdrop_contract_id: 5,
+        minter_address: minter_addr.clone(),
+        admin_account: creator.clone(),
+        app: &mut app,
+        per_address_limit: 1,
+    };
+    instantiate_contract(params);
 
-    instantiate_contract(
-        vec![eth_addr_str.clone()],
-        WHITELIST_AMOUNT,
-        5,
-        minter_addr.clone(),
-        creator.clone(),
-        &mut app,
-    );
     let stargaze_wallet_01 = Addr::unchecked(STARGAZE_WALLET_01);
     update_admin_for_whitelist(&mut app, creator, airdrop_contract.clone(), whiltelist_addr);
     send_funds_to_address(&mut app, STARGAZE_WALLET_01, MINT_PRICE);

--- a/contracts/sg-eth-airdrop/src/testing/tests/test_eth_whitelist.rs
+++ b/contracts/sg-eth-airdrop/src/testing/tests/test_eth_whitelist.rs
@@ -3,6 +3,7 @@ use crate::tests_folder::claim_constants::{MOCK_AIRDROP_ADDR_STR, MOCK_MINTER_AD
 use crate::tests_folder::collection_constants::WHITELIST_AMOUNT;
 use crate::tests_folder::setup_contracts::{custom_mock_app, instantiate_contract};
 use crate::tests_folder::setup_minter::configure_mock_minter_with_mock_whitelist;
+use crate::tests_folder::test_msgs::InstantiateParams;
 use cosmwasm_std::Addr;
 use cw_multi_test::Executor;
 
@@ -19,14 +20,16 @@ fn test_instantiate_with_addresses() {
     let minter_addr = Addr::unchecked(MOCK_MINTER_ADDR_STR);
     let airdrop_contract = Addr::unchecked(MOCK_AIRDROP_ADDR_STR);
 
-    instantiate_contract(
+    let params = InstantiateParams {
         addresses,
-        WHITELIST_AMOUNT,
-        4,
-        minter_addr,
-        Addr::unchecked(OWNER),
-        &mut app,
-    );
+        funds_amount: WHITELIST_AMOUNT,
+        expected_airdrop_contract_id: 4,
+        minter_address: minter_addr,
+        admin_account: Addr::unchecked(OWNER),
+        app: &mut app,
+        per_address_limit: 1,
+    };
+    instantiate_contract(params);
 
     let query_msg = QueryMsg::AirdropEligible {
         eth_address: "addr1".to_string(),
@@ -53,14 +56,17 @@ fn test_not_authorized_add_eth() {
     configure_mock_minter_with_mock_whitelist(&mut app);
     let minter_addr = Addr::unchecked(MOCK_MINTER_ADDR_STR);
     let airdrop_contract = Addr::unchecked(MOCK_AIRDROP_ADDR_STR);
-    instantiate_contract(
-        vec![],
-        WHITELIST_AMOUNT,
-        4,
-        minter_addr,
-        Addr::unchecked(OWNER),
-        &mut app,
-    );
+
+    let params = InstantiateParams {
+        addresses: vec![],
+        funds_amount: WHITELIST_AMOUNT,
+        expected_airdrop_contract_id: 4,
+        minter_address: minter_addr,
+        admin_account: Addr::unchecked(OWNER),
+        app: &mut app,
+        per_address_limit: 1,
+    };
+    instantiate_contract(params);
 
     let fake_admin = Addr::unchecked("fake_admin");
     let eth_address = Addr::unchecked("testing_addr");
@@ -79,14 +85,17 @@ fn test_authorized_add_eth() {
     configure_mock_minter_with_mock_whitelist(&mut app);
     let minter_addr = Addr::unchecked(MOCK_MINTER_ADDR_STR);
     let airdrop_contract = Addr::unchecked(MOCK_AIRDROP_ADDR_STR);
-    instantiate_contract(
-        vec![],
-        WHITELIST_AMOUNT,
-        4,
-        minter_addr,
-        Addr::unchecked(OWNER),
-        &mut app,
-    );
+
+    let params = InstantiateParams {
+        addresses: vec![],
+        funds_amount: WHITELIST_AMOUNT,
+        expected_airdrop_contract_id: 4,
+        minter_address: minter_addr,
+        admin_account: Addr::unchecked(OWNER),
+        app: &mut app,
+        per_address_limit: 1,
+    };
+    instantiate_contract(params);
 
     let eth_address = Addr::unchecked("testing_addr");
     let execute_msg = ExecuteMsg::AddEligibleEth {
@@ -104,14 +113,17 @@ fn test_add_eth_and_verify() {
     let minter_addr = Addr::unchecked(MOCK_MINTER_ADDR_STR);
     let airdrop_contract = Addr::unchecked(MOCK_AIRDROP_ADDR_STR);
 
-    instantiate_contract(
-        vec![],
-        WHITELIST_AMOUNT,
-        4,
-        minter_addr,
-        Addr::unchecked(OWNER),
-        &mut app,
-    );
+    let params = InstantiateParams {
+        addresses: vec![],
+        funds_amount: WHITELIST_AMOUNT,
+        expected_airdrop_contract_id: 4,
+        minter_address: minter_addr,
+        admin_account: Addr::unchecked(OWNER),
+        app: &mut app,
+        per_address_limit: 1,
+    };
+    instantiate_contract(params);
+
     let eth_address_str = Addr::unchecked("testing_addr").to_string();
     let execute_msg = ExecuteMsg::AddEligibleEth {
         eth_addresses: vec![eth_address_str.clone()],


### PR DESCRIPTION
In the original implementation, I forgot to incorporate the process addresses functionality of the generic whitelist. That functionality allows someone to specify how many mints are allowed in the per_address_limit flag. 

In this PR I am using the process method from generic whitelist that will decrement the count of allowed mints for that user. Before it was only removing the address from the list on mint for yes/no result. 