### PR TITLE
SG-396 Port discount price code from launchpad v1 to vending-minter

### DIFF
--- a/contracts/vending-minter/schema/config_response.json
+++ b/contracts/vending-minter/schema/config_response.json
@@ -20,6 +20,16 @@
     "base_token_uri": {
       "type": "string"
     },
+    "discount_price": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Coin"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "factory": {
       "type": "string"
     },

--- a/contracts/vending-minter/schema/execute_msg.json
+++ b/contracts/vending-minter/schema/execute_msg.json
@@ -200,6 +200,42 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "update_discount_price"
+      ],
+      "properties": {
+        "update_discount_price": {
+          "type": "object",
+          "required": [
+            "price"
+          ],
+          "properties": {
+            "price": {
+              "type": "integer",
+              "format": "uint128",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "remove_discount_price"
+      ],
+      "properties": {
+        "remove_discount_price": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/contracts/vending-minter/schema/mint_price_response.json
+++ b/contracts/vending-minter/schema/mint_price_response.json
@@ -14,6 +14,16 @@
     "current_price": {
       "$ref": "#/definitions/Coin"
     },
+    "discount_price": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Coin"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "public_price": {
       "$ref": "#/definitions/Coin"
     },

--- a/contracts/vending-minter/schema/minter_config_for__config_extension.json
+++ b/contracts/vending-minter/schema/minter_config_for__config_extension.json
@@ -62,6 +62,16 @@
         "base_token_uri": {
           "type": "string"
         },
+        "discount_price": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Coin"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "num_tokens": {
           "type": "integer",
           "format": "uint32",

--- a/contracts/vending-minter/src/contract.rs
+++ b/contracts/vending-minter/src/contract.rs
@@ -276,13 +276,6 @@ pub fn execute_update_discount_price(
         });
     }
 
-    // // Check that the price is greater than the minimum
-    // if MIN_MINT_PRICE > price {
-    //     return Err(ContractError::InsufficientMintPrice {
-    //         expected: MIN_MINT_PRICE,
-    //         got: price,
-    //     });
-    // }
     config.extension.discount_price = Some(coin(price, config.mint_price.denom.clone()));
     CONFIG.save(deps.storage, &config)?;
 
@@ -981,7 +974,6 @@ pub fn mint_price(deps: Deps, is_admin: bool) -> Result<Coin, StdError> {
     }
 
     if config.extension.whitelist.is_none() {
-        println!("we are config extension whitelist none price");
         return Ok(config.mint_price);
     }
 
@@ -992,10 +984,8 @@ pub fn mint_price(deps: Deps, is_admin: bool) -> Result<Coin, StdError> {
         .query_wasm_smart(whitelist, &WhitelistQueryMsg::Config {})?;
 
     if wl_config.is_active {
-        println!("we are in whitelist price");
         Ok(wl_config.mint_price)
     } else {
-        println!("we are in the price branch");
         let price = config.extension.discount_price.unwrap_or(config.mint_price);
         Ok(price)
     }

--- a/contracts/vending-minter/src/contract.rs
+++ b/contracts/vending-minter/src/contract.rs
@@ -974,7 +974,8 @@ pub fn mint_price(deps: Deps, is_admin: bool) -> Result<Coin, StdError> {
     }
 
     if config.extension.whitelist.is_none() {
-        return Ok(config.mint_price);
+        let price = config.extension.discount_price.unwrap_or(config.mint_price);
+        return Ok(price);
     }
 
     let whitelist = config.extension.whitelist.unwrap();

--- a/contracts/vending-minter/src/msg.rs
+++ b/contracts/vending-minter/src/msg.rs
@@ -33,6 +33,10 @@ pub enum ExecuteMsg {
     },
     Shuffle {},
     BurnRemaining {},
+    UpdateDiscountPrice {
+        price: u128,
+    },
+    RemoveDiscountPrice {},
 }
 
 #[cw_serde]
@@ -57,6 +61,7 @@ pub struct ConfigResponse {
     pub mint_price: Coin,
     pub whitelist: Option<String>,
     pub factory: String,
+    pub discount_price: Option<Coin>,
 }
 
 #[cw_serde]
@@ -75,6 +80,7 @@ pub struct MintPriceResponse {
     pub airdrop_price: Coin,
     pub whitelist_price: Option<Coin>,
     pub current_price: Coin,
+    pub discount_price: Option<Coin>,
 }
 
 #[cw_serde]

--- a/contracts/vending-minter/src/state.rs
+++ b/contracts/vending-minter/src/state.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, Timestamp};
+use cosmwasm_std::{Addr, Coin, Timestamp};
 use cw_storage_plus::{Item, Map};
 use sg4::{MinterConfig, Status};
 
@@ -12,6 +12,7 @@ pub struct ConfigExtension {
     pub whitelist: Option<Addr>,
     pub start_time: Timestamp,
     pub per_address_limit: u32,
+    pub discount_price: Option<Coin>,
 }
 pub type Config = MinterConfig<ConfigExtension>;
 

--- a/test-suite/src/vending_minter/tests/mint_and_burn.rs
+++ b/test-suite/src/vending_minter/tests/mint_and_burn.rs
@@ -188,11 +188,34 @@ fn update_discount_mint_price() {
     let mint_msg = ExecuteMsg::Mint {};
     let res = router.execute_contract(
         buyer,
-        minter_addr,
+        minter_addr.clone(),
         &mint_msg,
         &coins(MINT_PRICE - 5, NATIVE_DENOM),
     );
     assert!(res.is_ok());
+
+    // update discount price to MINT_PRICE - 5
+    let remove_discount_msg = ExecuteMsg::RemoveDiscountPrice {};
+    let res = router.execute_contract(
+        creator.clone(),
+        minter_addr.clone(),
+        &remove_discount_msg,
+        &[],
+    );
+    assert!(res.is_ok());
+
+    // check price after remove discount price, should be mint price + 1
+    let res: vending_minter::msg::MintPriceResponse = router
+        .wrap()
+        .query_wasm_smart(minter_addr.clone(), &QueryMsg::MintPrice {})
+        .unwrap();
+    assert_eq!(
+        res.current_price,
+        Coin {
+            denom: "ustars".to_string(),
+            amount: Uint128::new(MINT_PRICE + 1)
+        }
+    );
 }
 
 #[test]

--- a/test-suite/src/vending_minter/tests/mint_and_burn.rs
+++ b/test-suite/src/vending_minter/tests/mint_and_burn.rs
@@ -194,7 +194,7 @@ fn update_discount_mint_price() {
     );
     assert!(res.is_ok());
 
-    // update discount price to MINT_PRICE - 5
+    // remove discount price
     let remove_discount_msg = ExecuteMsg::RemoveDiscountPrice {};
     let res = router.execute_contract(
         creator.clone(),

--- a/test-suite/src/vending_minter/tests/mint_and_burn.rs
+++ b/test-suite/src/vending_minter/tests/mint_and_burn.rs
@@ -207,7 +207,7 @@ fn update_discount_mint_price() {
     // check price after remove discount price, should be mint price + 1
     let res: vending_minter::msg::MintPriceResponse = router
         .wrap()
-        .query_wasm_smart(minter_addr.clone(), &QueryMsg::MintPrice {})
+        .query_wasm_smart(minter_addr, &QueryMsg::MintPrice {})
         .unwrap();
     assert_eq!(
         res.current_price,


### PR DESCRIPTION
Linear link: https://linear.app/stargaze/issue/SG-396/port-discount-price-from-launchpad-v1-to-v2

Porting code from launchpad v1 to vending-minter : https://github.com/public-awesome/launchpad/pull/469

All of the required functionality is tested in `update_discount_mint_price` under `test-suite/src/vending_minter/tests/mint_and_burn.rs`. There was not a unit test before as far as I know. 