### PR TITLE
Fix Airdrop Claim Message

### DIFF
--- a/contracts/sg-eth-airdrop/src/claim_airdrop.rs
+++ b/contracts/sg-eth-airdrop/src/claim_airdrop.rs
@@ -150,7 +150,6 @@ mod validation {
         eth_address: String,
     ) -> StdResult<bool> {
         let plaintext_msg = compute_plaintext_msg(config, &eth_address);
-        println!("plaintext msg is {}", plaintext_msg);
         match hex::decode(eth_sig.clone()) {
             Ok(eth_sig_hex) => {
                 verify_ethereum_text(deps.as_ref(), &plaintext_msg, &eth_sig_hex, &eth_address)

--- a/test-suite/src/sg_eth_airdrop/constants/claim_constants.rs
+++ b/test-suite/src/sg_eth_airdrop/constants/claim_constants.rs
@@ -3,5 +3,5 @@ pub const MOCK_AIRDROP_ADDR_STR: &str = "contract3";
 pub const MOCK_MINTER_ADDR_STR: &str = "contract1";
 pub const STARGAZE_WALLET_01: &str = "0xstargaze_wallet_01";
 pub const STARGAZE_WALLET_02: &str = "0xstargaze_wallet_02";
-pub const CONFIG_PLAINTEXT: &str = "My Stargaze address is {wallet} and I want a Winter Pal.";
+pub const CONFIG_PLAINTEXT: &str = "My wallet is {wallet}, sign me up and rest in peace";
 pub const NATIVE_DENOM: &str = "ustars";

--- a/test-suite/src/sg_eth_airdrop/setup/setup_signatures.rs
+++ b/test-suite/src/sg_eth_airdrop/setup/setup_signatures.rs
@@ -10,21 +10,21 @@ pub async fn get_signature(
     wallet.sign_message(plaintext_msg).await
 }
 
-pub fn get_wallet_and_sig(
-    claim_plaintext: String,
-) -> (
+pub fn get_wallet_and_sig() -> (
     Wallet<ethers_core::k256::ecdsa::SigningKey>,
     std::string::String,
     H160,
     std::string::String,
 ) {
     let wallet = LocalWallet::new(&mut thread_rng());
+    let eth_addr = wallet.address();
+    let eth_addr_str = format!("{:?}", wallet.address());
+    let claim_plaintext = get_msg_plaintext(eth_addr_str.clone());
     let eth_sig_str = task::block_on(get_signature(wallet.clone(), &claim_plaintext))
         .unwrap()
         .to_string();
-    let eth_address = wallet.address();
-    let eth_addr_str = format!("{:?}", eth_address);
-    (wallet, eth_sig_str, eth_address, eth_addr_str)
+
+    (wallet, eth_sig_str, eth_addr, eth_addr_str)
 }
 
 pub fn get_msg_plaintext(wallet_address: String) -> String {

--- a/test-suite/src/sg_eth_airdrop/tests/test_claim.rs
+++ b/test-suite/src/sg_eth_airdrop/tests/test_claim.rs
@@ -37,8 +37,7 @@ fn query_minter_as_expected(app: &mut StargazeApp, airdrop_contract: Addr, minte
 fn test_instantiate() {
     let mut app = custom_mock_app();
     let minter_address = Addr::unchecked("contract1");
-    let claim_plaintext = &get_msg_plaintext(STARGAZE_WALLET_01.to_string());
-    let (_, _, _, eth_addr_str) = get_wallet_and_sig(claim_plaintext.clone());
+    let (_, _, _, eth_addr_str) = get_wallet_and_sig();
     let params = InstantiateParams {
         addresses: vec![eth_addr_str],
         funds_amount: WHITELIST_AMOUNT + INSTANTIATION_FEE,
@@ -57,8 +56,7 @@ fn test_instantiate_plaintext_too_long() {
     let long_config_plaintext: String = String::from_utf8(vec![b'X'; 1001]).unwrap() + " {wallet}";
     let mut app = custom_mock_app();
     let minter_address = Addr::unchecked("contract1");
-    let claim_plaintext = &get_msg_plaintext(STARGAZE_WALLET_01.to_string());
-    let (_, _, _, eth_addr_str) = get_wallet_and_sig(claim_plaintext.clone());
+    let (_, _, _, eth_addr_str) = get_wallet_and_sig();
     let params = InstantiateParams {
         addresses: vec![eth_addr_str],
         funds_amount: WHITELIST_AMOUNT + INSTANTIATION_FEE,
@@ -78,11 +76,10 @@ fn test_instantiate_plaintext_too_long() {
 
 #[test]
 fn test_instantiate_plaintext_missing_wallet() {
-    let plaintext_config_no_wallet = "This message doesn't have wallet string".to_string();
+    let config_plaintext = "This message doesn't have wallet string";
     let mut app = custom_mock_app();
     let minter_address = Addr::unchecked("contract1");
-    let claim_plaintext = &get_msg_plaintext(STARGAZE_WALLET_01.to_string());
-    let (_, _, _, eth_addr_str) = get_wallet_and_sig(claim_plaintext.clone());
+    let (_, _, _, eth_addr_str) = get_wallet_and_sig();
     let params = InstantiateParams {
         addresses: vec![eth_addr_str],
         funds_amount: WHITELIST_AMOUNT + INSTANTIATION_FEE,
@@ -91,7 +88,7 @@ fn test_instantiate_plaintext_missing_wallet() {
         admin_account: Addr::unchecked(OWNER),
         app: &mut app,
         per_address_limit: 1,
-        claim_msg_plaintext: plaintext_config_no_wallet,
+        claim_msg_plaintext: config_plaintext.to_string(),
     };
     let res = instantiate_contract(params).unwrap_err();
     assert_eq!(
@@ -102,8 +99,7 @@ fn test_instantiate_plaintext_missing_wallet() {
 
 #[test]
 fn test_valid_eth_sig_claim() {
-    let claim_plaintext = &get_msg_plaintext(STARGAZE_WALLET_01.to_string());
-    let (_, eth_sig_str, _, eth_addr_str) = get_wallet_and_sig(claim_plaintext.clone());
+    let (_, eth_sig_str, _, eth_addr_str) = get_wallet_and_sig();
     let mut app = custom_mock_app();
     configure_mock_minter_with_mock_whitelist(&mut app);
     let minter_addr = Addr::unchecked(MOCK_MINTER_ADDR_STR);
@@ -149,9 +145,8 @@ fn test_valid_eth_sig_claim() {
 
 #[test]
 fn test_invalid_eth_sig_claim() {
-    let claim_plaintext = &get_msg_plaintext(STARGAZE_WALLET_01.to_string());
-    let (_, _, _, eth_addr_str) = get_wallet_and_sig(claim_plaintext.clone());
-    let (_, eth_sig_str_2, _, _) = get_wallet_and_sig(claim_plaintext.clone());
+    let (_, _, _, eth_addr_str) = get_wallet_and_sig();
+    let (_, eth_sig_str_2, _, _) = get_wallet_and_sig();
 
     let mut app = custom_mock_app();
     configure_mock_minter_with_mock_whitelist(&mut app);
@@ -186,8 +181,7 @@ fn test_invalid_eth_sig_claim() {
 
 #[test]
 fn test_can_not_claim_twice() {
-    let claim_plaintext = &get_msg_plaintext(STARGAZE_WALLET_01.to_string());
-    let (_, eth_sig_str, _, eth_addr_str) = get_wallet_and_sig(claim_plaintext.clone());
+    let (_, eth_sig_str, _, eth_addr_str) = get_wallet_and_sig();
 
     let mut app = custom_mock_app();
     configure_mock_minter_with_mock_whitelist(&mut app);
@@ -245,8 +239,7 @@ fn test_can_not_claim_twice() {
 
 #[test]
 fn test_claim_one_valid_airdrop() {
-    let claim_plaintext = &get_msg_plaintext(STARGAZE_WALLET_01.to_string());
-    let (_, eth_sig_str, _, eth_addr_str) = get_wallet_and_sig(claim_plaintext.clone());
+    let (_, eth_sig_str, _, eth_addr_str) = get_wallet_and_sig();
 
     let stargaze_wallet_01 = Addr::unchecked(STARGAZE_WALLET_01);
 
@@ -295,8 +288,7 @@ fn test_claim_one_valid_airdrop() {
 
 #[test]
 fn test_claim_twice_receive_funds_once() {
-    let claim_plaintext = &get_msg_plaintext(STARGAZE_WALLET_01.to_string());
-    let (_, eth_sig_str, _, eth_addr_str) = get_wallet_and_sig(claim_plaintext.clone());
+    let (_, eth_sig_str, _, eth_addr_str) = get_wallet_and_sig();
 
     let stargaze_wallet_01 = Addr::unchecked(STARGAZE_WALLET_01);
     let mut app = custom_mock_app();
@@ -365,8 +357,7 @@ fn test_claim_twice_receive_funds_once() {
 
 #[test]
 fn test_ineligible_does_not_receive_funds() {
-    let claim_plaintext = &get_msg_plaintext(STARGAZE_WALLET_01.to_string());
-    let (_, _, _, eth_addr_str) = get_wallet_and_sig(claim_plaintext.clone());
+    let (_, _, _, eth_addr_str) = get_wallet_and_sig();
 
     let mut app = custom_mock_app();
     configure_mock_minter_with_mock_whitelist(&mut app);
@@ -392,8 +383,7 @@ fn test_ineligible_does_not_receive_funds() {
         .unwrap();
     assert_eq!(balances, []);
 
-    let claim_plaintext_2 = &get_msg_plaintext(STARGAZE_WALLET_02.to_string());
-    let (_, eth_sig_str_2, _, eth_addr_str_2) = get_wallet_and_sig(claim_plaintext_2.clone());
+    let (_, eth_sig_str_2, _, eth_addr_str_2) = get_wallet_and_sig();
 
     let claim_message = ExecuteMsg::ClaimAirdrop {
         eth_address: eth_addr_str_2.clone(),
@@ -418,12 +408,12 @@ fn test_one_eth_claim_two_stargaze_addresses_invalid() {
     let stargaze_wallet_01 = Addr::unchecked(STARGAZE_WALLET_01);
     let stargaze_wallet_02 = Addr::unchecked(STARGAZE_WALLET_02);
 
-    let claim_plaintext_1 = &get_msg_plaintext(STARGAZE_WALLET_01.to_string());
+    let eth_address = wallet_1.address();
+    let eth_addr_str_1 = format!("{:?}", eth_address);
+    let claim_plaintext_1 = &get_msg_plaintext(eth_addr_str_1.clone());
     let eth_sig_str_1 = task::block_on(get_signature(wallet_1.clone(), claim_plaintext_1))
         .unwrap()
         .to_string();
-    let eth_address = wallet_1.address();
-    let eth_addr_str_1 = format!("{:?}", eth_address);
 
     let mut app = custom_mock_app();
     configure_mock_minter_with_mock_whitelist(&mut app);
@@ -467,7 +457,7 @@ fn test_one_eth_claim_two_stargaze_addresses_invalid() {
     ];
     assert_eq!(res.events[1].attributes, expected_attributes);
 
-    let claim_plaintext_2 = &get_msg_plaintext(STARGAZE_WALLET_02.to_string());
+    let claim_plaintext_2 = &get_msg_plaintext(eth_addr_str_1.to_string());
     let eth_sig_str_2 = task::block_on(get_signature(wallet_1, claim_plaintext_2))
         .unwrap()
         .to_string();
@@ -492,8 +482,7 @@ fn test_one_eth_claim_two_stargaze_addresses_invalid() {
 
 #[test]
 fn test_two_claims_allowed_success() {
-    let claim_plaintext = &get_msg_plaintext(STARGAZE_WALLET_01.to_string());
-    let (_, eth_sig_str, _, eth_addr_str) = get_wallet_and_sig(claim_plaintext.clone());
+    let (_, eth_sig_str, _, eth_addr_str) = get_wallet_and_sig();
 
     let stargaze_wallet_01 = Addr::unchecked(STARGAZE_WALLET_01);
 

--- a/test-suite/src/sg_eth_airdrop/tests/test_collection_whitelist.rs
+++ b/test-suite/src/sg_eth_airdrop/tests/test_collection_whitelist.rs
@@ -9,7 +9,7 @@ use crate::sg_eth_airdrop::setup::collection_whitelist_helpers::{
     send_funds_to_address, update_admin_for_whitelist,
 };
 use crate::sg_eth_airdrop::setup::execute_msg::instantiate_contract;
-use crate::sg_eth_airdrop::setup::setup_signatures::{get_msg_plaintext, get_wallet_and_sig};
+use crate::sg_eth_airdrop::setup::setup_signatures::get_wallet_and_sig;
 use crate::sg_eth_airdrop::setup::test_msgs::InstantiateParams;
 use cosmwasm_std::Addr;
 use sg_eth_airdrop::msg::QueryMsg;
@@ -24,8 +24,7 @@ fn test_set_minter_contract_success() {
     let (mut app, creator) = (vt.router, vt.accts.creator);
     let minter_addr = vt.collection_response_vec[0].minter.clone().unwrap();
 
-    let claim_plaintext = &get_msg_plaintext(STARGAZE_WALLET_01.to_string());
-    let (_, _, _, eth_addr_str) = get_wallet_and_sig(claim_plaintext.clone());
+    let (_, _, _, eth_addr_str) = get_wallet_and_sig();
 
     let contract_admin = Addr::unchecked(creator);
     let params = InstantiateParams {
@@ -56,8 +55,7 @@ fn test_claim_added_to_minter_whitelist() {
     let whitelist_addr =
         configure_collection_whitelist(&mut app, creator.clone(), buyer, minter_addr.clone());
     setup_block_time(&mut app, GENESIS_MINT_START_TIME, None);
-    let claim_plaintext = &get_msg_plaintext(STARGAZE_WALLET_01.to_string());
-    let (_, eth_sig_str, _, eth_addr_str) = get_wallet_and_sig(claim_plaintext.clone());
+    let (_, eth_sig_str, _, eth_addr_str) = get_wallet_and_sig();
 
     let airdrop_contract = Addr::unchecked(AIRDROP_ADDR_STR);
     let params = InstantiateParams {


### PR DESCRIPTION
Was getting issues on airdrop claim because we are checking for the wrong eth signature plaintext. 

Before was checking for "My wallet is {stargaze_wallet}, sign me up and rest in peace";
Need to instead check for  "My wallet is {eth_address}, sign me up and rest in peace";

All unit tests updated to reflect the fix. 