### PR TITLE
add whitelist mint count to flex minter

### DIFF
--- a/contracts/minters/vending-minter-wl-flex/src/contract.rs
+++ b/contracts/minters/vending-minter-wl-flex/src/contract.rs
@@ -1101,9 +1101,12 @@ pub fn query_status(deps: Deps) -> StdResult<StatusResponse> {
 fn query_mint_count(deps: Deps, address: String) -> StdResult<MintCountResponse> {
     let addr = deps.api.addr_validate(&address)?;
     let mint_count = (MINTER_ADDRS.key(&addr).may_load(deps.storage)?).unwrap_or(0);
+    let whitelist_mint_count =
+        (WHITELIST_MINTER_ADDRS.key(&addr).may_load(deps.storage)?).unwrap_or(0);
     Ok(MintCountResponse {
         address: addr.to_string(),
         count: mint_count,
+        whitelist_count: whitelist_mint_count,
     })
 }
 

--- a/contracts/minters/vending-minter-wl-flex/src/msg.rs
+++ b/contracts/minters/vending-minter-wl-flex/src/msg.rs
@@ -95,4 +95,5 @@ pub struct MintPriceResponse {
 pub struct MintCountResponse {
     pub address: String,
     pub count: u32,
+    pub whitelist_count: u32,
 }


### PR DESCRIPTION
for vending-minter-flex we use different counters for whitelist and for public mint, however there is no way to retrieve such information without querying raw keys, this change adds the whitelist counter to the query response.