### PR TITLE
Use `Expiration` and `Duration` helpers

### DIFF
--- a/contracts/collections/sg721-base/src/contract.rs
+++ b/contracts/collections/sg721-base/src/contract.rs
@@ -5,10 +5,9 @@ use cosmwasm_std::{
 use cw721::{ContractInfoResponse as CW721ContractInfoResponse, Cw721Execute};
 use cw721_base::state::TokenInfo;
 use cw721_base::Extension;
-use cw_utils::{nonpayable, Duration, Expiration, DAY};
+use cw_utils::{nonpayable, Expiration, DAY};
 use serde::{de::DeserializeOwned, Serialize};
 use sg2::query::{ParamsResponse, Sg2QueryMsg};
-use sg2::ROYALTY_MIN_TIME_DURATION_SECS;
 use sg4::{MinterConfig, QueryMsg as MinterQueryMsg};
 use sg721::{CollectionInfo, ExecuteMsg, InstantiateMsg, RoyaltyInfo, UpdateCollectionInfoMsg};
 use sg_std::math::U64Ext;

--- a/packages/sg2/src/lib.rs
+++ b/packages/sg2/src/lib.rs
@@ -6,7 +6,6 @@ pub mod query;
 pub mod tests;
 
 pub type CodeId = u64;
-pub const ROYALTY_MIN_TIME_DURATION_SECS: u64 = 86400;
 
 /// Common params for all minters used for storage
 #[cw_serde]

--- a/test-suite/src/sg721_base/tests/integration_tests.rs
+++ b/test-suite/src/sg721_base/tests/integration_tests.rs
@@ -27,6 +27,7 @@ mod tests {
     const GOVERNANCE: &str = "governance";
     const ADMIN: &str = "admin";
     const NATIVE_DENOM: &str = "ustars";
+    const ROYALTY_MIN_TIME_DURATION_SECS: u64 = 86400;
 
     fn proper_instantiate_factory() -> (StargazeApp, FactoryContract) {
         let mut app = custom_mock_app();
@@ -242,7 +243,6 @@ mod tests {
 
     mod start_trading_time {
         use cosmwasm_std::{Decimal, Empty, Timestamp};
-        use sg2::ROYALTY_MIN_TIME_DURATION_SECS;
         use sg721::{RoyaltyInfo, UpdateCollectionInfoMsg};
         use sg721_base::ContractError;
 


### PR DESCRIPTION
`Expiration` and `Duration` in cw-utils help with working with duration and block times. It makes the code more readable imho. Also a `DAY` constant is already provided so no need to add it to Stargaze packages.