### PR TITLE
Update minter and collection ownership

### DIFF
--- a/contracts/collections/sg721-base/src/contract.rs
+++ b/contracts/collections/sg721-base/src/contract.rs
@@ -246,14 +246,12 @@ where
 
                     if share_delta > Decimal::percent(MAX_SHARE_DELTA_PCT) {
                         return Err(ContractError::InvalidRoyalties(format!(
-                            "Share increase cannot be greater than {}%",
-                            MAX_SHARE_DELTA_PCT
+                            "Share increase cannot be greater than {MAX_SHARE_DELTA_PCT}%"
                         )));
                     }
                     if new_royalty_info.share > Decimal::percent(MAX_ROYALTY_SHARE_PCT) {
                         return Err(ContractError::InvalidRoyalties(format!(
-                            "Share cannot be greater than {}%",
-                            MAX_ROYALTY_SHARE_PCT
+                            "Share cannot be greater than {MAX_ROYALTY_SHARE_PCT}%"
                         )));
                     }
                 }

--- a/contracts/collections/sg721-base/src/error.rs
+++ b/contracts/collections/sg721-base/src/error.rs
@@ -17,6 +17,9 @@ pub enum ContractError {
     #[error("{0}")]
     Base(#[from] cw721_base::ContractError),
 
+    #[error("{0}")]
+    Ownership(#[from] cw_ownable::OwnershipError),
+
     #[error("Unauthorized")]
     Unauthorized {},
 

--- a/contracts/collections/sg721-updatable/src/contract.rs
+++ b/contracts/collections/sg721-updatable/src/contract.rs
@@ -1,24 +1,22 @@
 use crate::error::ContractError;
-use crate::state::FROZEN_TOKEN_METADATA;
-use cosmwasm_std::{Empty, StdError, Uint128};
-
-use cosmwasm_std::{Deps, StdResult};
-
-#[cfg(not(feature = "library"))]
-use cosmwasm_std::{DepsMut, Env, Event, MessageInfo};
-use cw2::set_contract_version;
-use semver::Version;
-use sg721::InstantiateMsg;
-use sg721_base::contract::only_minter;
-
 use crate::msg::{EnableUpdatableResponse, FrozenTokenMetadataResponse};
 use crate::state::ENABLE_UPDATABLE;
-
+use crate::state::FROZEN_TOKEN_METADATA;
+use cosmwasm_std::{Deps, StdResult};
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::{DepsMut, Env, Event, MessageInfo};
+use cosmwasm_std::{Empty, StdError, Uint128};
+use cw2::set_contract_version;
 use cw721_base::Extension;
 use cw_utils::nonpayable;
+use semver::Version;
 use sg1::checked_fair_burn;
+use sg721::InstantiateMsg;
+use sg721_base::contract::only_minter;
+use sg721_base::msg::CollectionInfoResponse;
 use sg721_base::Sg721Contract;
 pub type Sg721UpdatableContract<'a> = Sg721Contract<'a, Extension>;
+use sg721_base::ContractError::Unauthorized;
 use sg_std::Response;
 
 const CONTRACT_NAME: &str = "crates.io:sg721-updatable";


### PR DESCRIPTION
There's confusion over collection owners and minters right now. To clarify it, I propose we move to this solution:

* Replace the minter admin with [cw-ownable](https://github.com/larry0x/cw-plus-plus/tree/main/packages/ownable)
* Make collections read-only
* Only minters can write / update collections
* Collections only have minters as owners

So now collection administration is passed through from the minter. We don't have to check `creator` in `CollectionInfo` anymore.

So now:
* Minters have a transferrable owner that can be an EOA, multisig, or DAO
* Collections are always "owned" by minters
* Collection update have to pass through minters

TODO:
- [ ] Replace `admin` in `ConfigExtension` with `cw-ownable`.
- [ ] Add a migration to to minters to migrate `admin` to `cw-ownable`.
- [ ]  `UpdateCollectionInfo {}` and others can be added to the minter as well

NOTE:
Here's how to do extend cw721 execute messages the "proper" way: https://github.com/public-awesome/core/pull/16/files#diff-b5b5b8636528b3755dac1ab0e2d1c015b3fbcf730232bdc68e6fd81352a3a3e1R61
