### PR TITLE
Burn to Mint [rebase main]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,11 +285,13 @@ dependencies = [
  "cw-storage-plus 1.1.0",
  "cw-utils 1.0.1",
  "cw2 1.1.0",
+ "cw721-base 0.18.0",
  "schemars",
  "serde",
  "sg-std",
  "sg1",
  "sg2",
+ "sg721-base",
  "thiserror",
 ]
 
@@ -298,6 +300,7 @@ name = "base-minter"
 version = "3.1.0"
 dependencies = [
  "base-factory",
+ "burn-to-mint",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 1.1.0",
@@ -539,6 +542,30 @@ name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+
+[[package]]
+name = "burn-to-mint"
+version = "3.1.0"
+dependencies = [
+ "base-factory",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 1.1.0",
+ "cw-utils 1.0.1",
+ "cw2 1.1.0",
+ "cw721 0.18.0",
+ "cw721-base 0.18.0",
+ "schemars",
+ "serde",
+ "sg-std",
+ "sg1",
+ "sg2",
+ "sg4",
+ "sg721",
+ "sg721-base",
+ "thiserror",
+ "url",
+]
 
 [[package]]
 name = "byte-slice-cast"
@@ -2296,15 +2323,19 @@ dependencies = [
 name = "open-edition-minter"
 version = "3.1.0"
 dependencies = [
+ "base-minter",
+ "burn-to-mint",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 1.1.0",
  "cw-utils 1.0.1",
  "cw2 1.1.0",
+ "cw721 0.18.0",
  "cw721-base 0.18.0",
  "open-edition-factory",
  "semver",
  "serde",
+ "sg-controllers",
  "sg-metadata",
  "sg-std",
  "sg1",
@@ -3360,6 +3391,7 @@ dependencies = [
  "cosmwasm-std",
  "schemars",
  "serde",
+ "sg2",
  "thiserror",
 ]
 
@@ -4227,6 +4259,7 @@ dependencies = [
 name = "vending-minter"
 version = "3.1.0"
 dependencies = [
+ "burn-to-mint",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 1.1.0",
@@ -4239,6 +4272,7 @@ dependencies = [
  "schemars",
  "semver",
  "serde",
+ "sg-controllers",
  "sg-std",
  "sg-whitelist",
  "sg1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ open-edition-minter  = { version = "3.1.0", path = "contracts/minters/open-editi
 whitelist-immutable  = { version = "3.1.0", path = "contracts/whitelists/whitelist-immutable" }
 sg-whitelist-flex    = { version = "3.1.0", path = "contracts/whitelists/whitelist-flex" }
 ethereum-verify      = { version = "3.1.0", path = "packages/ethereum-verify" }
+burn-to-mint         = { version = "3.1.0", path = "packages/burn-to-mint" }
 sg-eth-airdrop       = { version = "3.1.0", path = "contracts/sg-eth-airdrop" }
 test-suite           = { version = "3.1.0", path = "test-suite" }
 semver               = "1"

--- a/contracts/collections/sg721-base/src/error.rs
+++ b/contracts/collections/sg721-base/src/error.rs
@@ -55,4 +55,10 @@ pub enum ContractError {
 
     #[error("Error while migrating: ({0}) ")]
     MigrationError(String),
+
+    #[error("Contract ownership has been renounced")]
+    NoOwner,
+
+    #[error("Caller is not the contract's current owner")]
+    NotOwner,
 }

--- a/contracts/collections/sg721-updatable/src/contract.rs
+++ b/contracts/collections/sg721-updatable/src/contract.rs
@@ -22,7 +22,7 @@ use sg721_base::Sg721Contract;
 pub type Sg721UpdatableContract<'a> = Sg721Contract<'a, Extension>;
 use sg_std::Response;
 
-const CONTRACT_NAME: &str = "crates.io:sg721-updatable";
+const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 const EARLIEST_COMPATIBLE_VERSION: &str = "0.16.0";
 const COMPATIBLE_CONTRACT_NAMES_FOR_MIGRATION: [&str; 4] = [

--- a/contracts/factories/base-factory/Cargo.toml
+++ b/contracts/factories/base-factory/Cargo.toml
@@ -35,5 +35,7 @@ schemars        = { workspace = true }
 serde           = { workspace = true }
 sg1             = { workspace = true }
 sg2             = { workspace = true }
+cw721-base = { workspace = true, features = ["library"] }
+sg721-base      = { workspace = true, features = ["library"]} 
 sg-std          = { workspace = true }
 thiserror       = { workspace = true }

--- a/contracts/factories/base-factory/src/error.rs
+++ b/contracts/factories/base-factory/src/error.rs
@@ -28,4 +28,10 @@ pub enum ContractError {
 
     #[error("InvalidCollectionCodeId {code_id}")]
     InvalidCollectionCodeId { code_id: u64 },
+
+    #[error("InvalidCollectionAddress")]
+    InvalidCollectionAddress {},
+
+    #[error("NoMinterForNonfungibleToken")]
+    NoMinterForNonfungibleToken {},
 }

--- a/contracts/factories/open-edition-factory/schema/instantiate_msg.json
+++ b/contracts/factories/open-edition-factory/schema/instantiate_msg.json
@@ -70,7 +70,7 @@
           "minimum": 0.0
         },
         "min_mint_price": {
-          "$ref": "#/definitions/Coin"
+          "$ref": "#/definitions/Token"
         },
         "mint_fee_bps": {
           "type": "integer",
@@ -107,6 +107,34 @@
         }
       },
       "additionalProperties": false
+    },
+    "Token": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "fungible"
+          ],
+          "properties": {
+            "fungible": {
+              "$ref": "#/definitions/Coin"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "non_fungible"
+          ],
+          "properties": {
+            "non_fungible": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
     },
     "Uint128": {
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",

--- a/contracts/factories/open-edition-factory/src/msg.rs
+++ b/contracts/factories/open-edition-factory/src/msg.rs
@@ -58,7 +58,8 @@ impl OpenEditionMinterInitMsgExtension {
             ));
         }
 
-        if init_msg.mint_price.amount < params.min_mint_price.amount {
+        let min_mint_price = params.min_mint_price.clone().amount()?;
+        if init_msg.mint_price.amount < min_mint_price {
             return Err(ContractError::InvalidMintPrice {});
         }
 

--- a/contracts/factories/vending-factory/schema/instantiate_msg.json
+++ b/contracts/factories/vending-factory/schema/instantiate_msg.json
@@ -70,7 +70,7 @@
           "minimum": 0.0
         },
         "min_mint_price": {
-          "$ref": "#/definitions/Coin"
+          "$ref": "#/definitions/Token"
         },
         "mint_fee_bps": {
           "type": "integer",
@@ -114,6 +114,34 @@
         }
       },
       "additionalProperties": false
+    },
+    "Token": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "fungible"
+          ],
+          "properties": {
+            "fungible": {
+              "$ref": "#/definitions/Coin"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "non_fungible"
+          ],
+          "properties": {
+            "non_fungible": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
     },
     "Uint128": {
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",

--- a/contracts/factories/vending-factory/src/contract.rs
+++ b/contracts/factories/vending-factory/src/contract.rs
@@ -82,15 +82,16 @@ pub fn execute_create_minter(
             got: msg.init_msg.per_address_limit,
         });
     }
-
+    let denom_min_mint_price = params.min_mint_price.clone().denom()?;
     ensure!(
-        params.min_mint_price.denom == msg.init_msg.mint_price.denom,
+        denom_min_mint_price == msg.init_msg.mint_price.denom,
         ContractError::DenomMismatch {}
     );
 
-    if params.min_mint_price.amount > msg.init_msg.mint_price.amount {
+    let params_min_mint_price = params.min_mint_price.amount()?;
+    if params_min_mint_price > msg.init_msg.mint_price.amount {
         return Err(ContractError::InsufficientMintPrice {
-            expected: params.min_mint_price.amount.u128(),
+            expected: params_min_mint_price.into(),
             got: msg.init_msg.mint_price.amount.into(),
         });
     }
@@ -123,7 +124,7 @@ pub fn sudo_update_params(
 ) -> Result<Response, ContractError> {
     let mut params = SUDO_PARAMS.load(deps.storage)?;
 
-    update_params(&mut params, param_msg.clone())?;
+    update_params(&mut params, param_msg.clone(), deps.as_ref())?;
 
     params.extension.max_token_limit = param_msg
         .extension

--- a/contracts/minters/base-minter/Cargo.toml
+++ b/contracts/minters/base-minter/Cargo.toml
@@ -44,3 +44,4 @@ sg721-base      = { workspace = true, features = ["library"] }
 sg-std          = { workspace = true }
 thiserror       = { workspace = true }
 url             = { workspace = true }
+burn-to-mint    = { workspace = true }

--- a/contracts/minters/base-minter/src/error.rs
+++ b/contracts/minters/base-minter/src/error.rs
@@ -41,4 +41,7 @@ pub enum ContractError {
 
     #[error("InvalidStartTradingTime {0} < {1}")]
     InvalidStartTradingTime(Timestamp, Timestamp),
+
+    #[error("Burn to Mint Error")]
+    BurnToMintError {},
 }

--- a/contracts/minters/base-minter/src/msg.rs
+++ b/contracts/minters/base-minter/src/msg.rs
@@ -1,6 +1,7 @@
 use base_factory::{msg::BaseMinterCreateMsg, state::BaseMinterParams};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Empty, Timestamp};
+use cw721::Cw721ReceiveMsg;
 use sg4::MinterConfigResponse;
 
 #[cw_serde]
@@ -10,8 +11,15 @@ pub struct InstantiateMsg {
 }
 
 #[cw_serde]
+pub struct TokenUriMsg {
+    pub token_uri: String,
+}
+
+#[cw_serde]
 pub enum ExecuteMsg {
     Mint { token_uri: String },
+    ReceiveNft(Cw721ReceiveMsg), // burn-to-mint
+    // SendNft(Cw721ReceiveMsg),
     UpdateStartTradingTime(Option<Timestamp>),
 }
 

--- a/contracts/minters/open-edition-minter/Cargo.toml
+++ b/contracts/minters/open-edition-minter/Cargo.toml
@@ -36,10 +36,14 @@ serde                   = { workspace = true }
 sg1                     = { workspace = true }
 sg2                     = { workspace = true }
 sg4                     = { workspace = true }
+cw721                   = { workspace = true }
 sg721                   = { workspace = true }
 sg-std                  = { workspace = true }
 sg-metadata             = { workspace = true }
 thiserror               = { workspace = true }
 url                     = { workspace = true }
 open-edition-factory    = { workspace = true, features = ["library"] }
-semver                  = {workspace = true }
+semver                  = { workspace = true }
+burn-to-mint            = { workspace = true }
+base-minter             = { workspace = true }
+sg-controllers          = { workspace = true }

--- a/contracts/minters/open-edition-minter/schema/execute_msg.json
+++ b/contracts/minters/open-edition-minter/schema/execute_msg.json
@@ -138,9 +138,46 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "receive_nft"
+      ],
+      "properties": {
+        "receive_nft": {
+          "$ref": "#/definitions/Cw721ReceiveMsg"
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {
+    "Binary": {
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+      "type": "string"
+    },
+    "Cw721ReceiveMsg": {
+      "description": "Cw721ReceiveMsg should be de/serialized under `Receive()` variant in a ExecuteMsg",
+      "type": "object",
+      "required": [
+        "msg",
+        "sender",
+        "token_id"
+      ],
+      "properties": {
+        "msg": {
+          "$ref": "#/definitions/Binary"
+        },
+        "sender": {
+          "type": "string"
+        },
+        "token_id": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
     "Timestamp": {
       "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
       "allOf": [

--- a/contracts/minters/open-edition-minter/schema/instantiate_msg.json
+++ b/contracts/minters/open-edition-minter/schema/instantiate_msg.json
@@ -16,6 +16,10 @@
   },
   "additionalProperties": false,
   "definitions": {
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
     "Coin": {
       "type": "object",
       "required": [
@@ -117,6 +121,15 @@
         "init_msg"
       ],
       "properties": {
+        "allowed_burn_collections": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Addr"
+          }
+        },
         "collection_params": {
           "$ref": "#/definitions/CollectionParams"
         },
@@ -246,7 +259,7 @@
           "minimum": 0.0
         },
         "min_mint_price": {
-          "$ref": "#/definitions/Coin"
+          "$ref": "#/definitions/Token"
         },
         "mint_fee_bps": {
           "type": "integer",
@@ -376,6 +389,34 @@
       "allOf": [
         {
           "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Token": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "fungible"
+          ],
+          "properties": {
+            "fungible": {
+              "$ref": "#/definitions/Coin"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "non_fungible"
+          ],
+          "properties": {
+            "non_fungible": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
         }
       ]
     },

--- a/contracts/minters/open-edition-minter/schema/minter_config_for__config_extension.json
+++ b/contracts/minters/open-edition-minter/schema/minter_config_for__config_extension.json
@@ -10,6 +10,15 @@
     "mint_price"
   ],
   "properties": {
+    "allowed_burn_collections": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/Addr"
+      }
+    },
     "collection_code_id": {
       "type": "integer",
       "format": "uint64",
@@ -22,7 +31,7 @@
       "$ref": "#/definitions/Addr"
     },
     "mint_price": {
-      "$ref": "#/definitions/Coin"
+      "$ref": "#/definitions/Token"
     }
   },
   "additionalProperties": false,
@@ -199,6 +208,34 @@
       "allOf": [
         {
           "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Token": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "fungible"
+          ],
+          "properties": {
+            "fungible": {
+              "$ref": "#/definitions/Coin"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "non_fungible"
+          ],
+          "properties": {
+            "non_fungible": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
         }
       ]
     },

--- a/contracts/minters/open-edition-minter/src/error.rs
+++ b/contracts/minters/open-edition-minter/src/error.rs
@@ -54,7 +54,6 @@ pub enum ContractError {
 
     #[error("Minimum network mint price {expected} got {got}")]
     InsufficientMintPrice { expected: u128, got: u128 },
-
     #[error("Minimum whitelist mint price {expected} got {got}")]
     InsufficientWhitelistMintPrice { expected: u128, got: u128 },
 
@@ -114,4 +113,10 @@ pub enum ContractError {
 
     #[error("Multiply Fraction Error")]
     CheckedMultiplyFractionError {},
+
+    #[error("Expected fungible token, received nonfungible")]
+    IncorrectFungibility {},
+
+    #[error("Burn to Mint Error")]
+    BurnToMintError {},
 }

--- a/contracts/minters/open-edition-minter/src/msg.rs
+++ b/contracts/minters/open-edition-minter/src/msg.rs
@@ -1,6 +1,7 @@
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Coin, Timestamp};
 
+use cw721::Cw721ReceiveMsg;
 use open_edition_factory::types::NftData;
 use open_edition_factory::{msg::OpenEditionMinterCreateMsg, state::OpenEditionMinterParams};
 
@@ -27,6 +28,7 @@ pub enum ExecuteMsg {
     MintTo {
         recipient: String,
     },
+    ReceiveNft(Cw721ReceiveMsg),
 }
 
 #[cw_serde]
@@ -85,4 +87,9 @@ pub struct MintCountResponse {
 #[cw_serde]
 pub struct TotalMintCountResponse {
     pub count: u32,
+}
+
+#[cw_serde]
+pub struct TokenUriMsg {
+    pub token_uri: String,
 }

--- a/contracts/minters/vending-minter-wl-flex/schema/raw/execute.json
+++ b/contracts/minters/vending-minter-wl-flex/schema/raw/execute.json
@@ -1,0 +1,255 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ExecuteMsg",
+  "oneOf": [
+    {
+      "type": "object",
+      "required": [
+        "mint"
+      ],
+      "properties": {
+        "mint": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "set_whitelist"
+      ],
+      "properties": {
+        "set_whitelist": {
+          "type": "object",
+          "required": [
+            "whitelist"
+          ],
+          "properties": {
+            "whitelist": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "purge"
+      ],
+      "properties": {
+        "purge": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "update_mint_price"
+      ],
+      "properties": {
+        "update_mint_price": {
+          "type": "object",
+          "required": [
+            "price"
+          ],
+          "properties": {
+            "price": {
+              "type": "integer",
+              "format": "uint128",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "update_start_time"
+      ],
+      "properties": {
+        "update_start_time": {
+          "$ref": "#/definitions/Timestamp"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Runs custom checks against TradingStartTime on VendingMinter, then updates by calling sg721-base",
+      "type": "object",
+      "required": [
+        "update_start_trading_time"
+      ],
+      "properties": {
+        "update_start_trading_time": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Timestamp"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "update_per_address_limit"
+      ],
+      "properties": {
+        "update_per_address_limit": {
+          "type": "object",
+          "required": [
+            "per_address_limit"
+          ],
+          "properties": {
+            "per_address_limit": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "mint_to"
+      ],
+      "properties": {
+        "mint_to": {
+          "type": "object",
+          "required": [
+            "recipient"
+          ],
+          "properties": {
+            "recipient": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "mint_for"
+      ],
+      "properties": {
+        "mint_for": {
+          "type": "object",
+          "required": [
+            "recipient",
+            "token_id"
+          ],
+          "properties": {
+            "recipient": {
+              "type": "string"
+            },
+            "token_id": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "shuffle"
+      ],
+      "properties": {
+        "shuffle": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "burn_remaining"
+      ],
+      "properties": {
+        "burn_remaining": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "update_discount_price"
+      ],
+      "properties": {
+        "update_discount_price": {
+          "type": "object",
+          "required": [
+            "price"
+          ],
+          "properties": {
+            "price": {
+              "type": "integer",
+              "format": "uint128",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "remove_discount_price"
+      ],
+      "properties": {
+        "remove_discount_price": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "definitions": {
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/minters/vending-minter-wl-flex/schema/raw/instantiate.json
+++ b/contracts/minters/vending-minter-wl-flex/schema/raw/instantiate.json
@@ -1,0 +1,326 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "InstantiateMsg",
+  "type": "object",
+  "required": [
+    "create_msg",
+    "params"
+  ],
+  "properties": {
+    "create_msg": {
+      "$ref": "#/definitions/CreateMinterMsg_for_VendingMinterInitMsgExtension"
+    },
+    "params": {
+      "$ref": "#/definitions/MinterParams_for_ParamsExtension"
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Coin": {
+      "type": "object",
+      "required": [
+        "amount",
+        "denom"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "denom": {
+          "type": "string"
+        }
+      }
+    },
+    "CollectionInfo_for_RoyaltyInfoResponse": {
+      "type": "object",
+      "required": [
+        "creator",
+        "description",
+        "image"
+      ],
+      "properties": {
+        "creator": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "explicit_content": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "external_link": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "image": {
+          "type": "string"
+        },
+        "royalty_info": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RoyaltyInfoResponse"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "start_trading_time": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Timestamp"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "CollectionParams": {
+      "type": "object",
+      "required": [
+        "code_id",
+        "info",
+        "name",
+        "symbol"
+      ],
+      "properties": {
+        "code_id": {
+          "description": "The collection code id",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "info": {
+          "$ref": "#/definitions/CollectionInfo_for_RoyaltyInfoResponse"
+        },
+        "name": {
+          "type": "string"
+        },
+        "symbol": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "CreateMinterMsg_for_VendingMinterInitMsgExtension": {
+      "type": "object",
+      "required": [
+        "collection_params",
+        "init_msg"
+      ],
+      "properties": {
+        "collection_params": {
+          "$ref": "#/definitions/CollectionParams"
+        },
+        "init_msg": {
+          "$ref": "#/definitions/VendingMinterInitMsgExtension"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Decimal": {
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "type": "string"
+    },
+    "MinterParams_for_ParamsExtension": {
+      "description": "Common params for all minters used for storage",
+      "type": "object",
+      "required": [
+        "allowed_sg721_code_ids",
+        "code_id",
+        "creation_fee",
+        "extension",
+        "frozen",
+        "max_trading_offset_secs",
+        "min_mint_price",
+        "mint_fee_bps"
+      ],
+      "properties": {
+        "allowed_sg721_code_ids": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          }
+        },
+        "code_id": {
+          "description": "The minter code id",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "creation_fee": {
+          "$ref": "#/definitions/Coin"
+        },
+        "extension": {
+          "$ref": "#/definitions/ParamsExtension"
+        },
+        "frozen": {
+          "type": "boolean"
+        },
+        "max_trading_offset_secs": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "min_mint_price": {
+          "$ref": "#/definitions/Token"
+        },
+        "mint_fee_bps": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "ParamsExtension": {
+      "description": "Parameters common to all vending minters, as determined by governance",
+      "type": "object",
+      "required": [
+        "airdrop_mint_fee_bps",
+        "airdrop_mint_price",
+        "max_per_address_limit",
+        "max_token_limit",
+        "shuffle_fee"
+      ],
+      "properties": {
+        "airdrop_mint_fee_bps": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "airdrop_mint_price": {
+          "$ref": "#/definitions/Coin"
+        },
+        "max_per_address_limit": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "max_token_limit": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "shuffle_fee": {
+          "$ref": "#/definitions/Coin"
+        }
+      },
+      "additionalProperties": false
+    },
+    "RoyaltyInfoResponse": {
+      "type": "object",
+      "required": [
+        "payment_address",
+        "share"
+      ],
+      "properties": {
+        "payment_address": {
+          "type": "string"
+        },
+        "share": {
+          "$ref": "#/definitions/Decimal"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Token": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "fungible"
+          ],
+          "properties": {
+            "fungible": {
+              "$ref": "#/definitions/Coin"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "non_fungible"
+          ],
+          "properties": {
+            "non_fungible": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
+    },
+    "VendingMinterInitMsgExtension": {
+      "type": "object",
+      "required": [
+        "base_token_uri",
+        "mint_price",
+        "num_tokens",
+        "per_address_limit",
+        "start_time"
+      ],
+      "properties": {
+        "base_token_uri": {
+          "type": "string"
+        },
+        "mint_price": {
+          "$ref": "#/definitions/Coin"
+        },
+        "num_tokens": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "payment_address": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "per_address_limit": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "start_time": {
+          "$ref": "#/definitions/Timestamp"
+        },
+        "whitelist": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/contracts/minters/vending-minter-wl-flex/schema/raw/query.json
+++ b/contracts/minters/vending-minter-wl-flex/schema/raw/query.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "QueryMsg",
+  "oneOf": [
+    {
+      "type": "object",
+      "required": [
+        "config"
+      ],
+      "properties": {
+        "config": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "mintable_num_tokens"
+      ],
+      "properties": {
+        "mintable_num_tokens": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "start_time"
+      ],
+      "properties": {
+        "start_time": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "mint_price"
+      ],
+      "properties": {
+        "mint_price": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "mint_count"
+      ],
+      "properties": {
+        "mint_count": {
+          "type": "object",
+          "required": [
+            "address"
+          ],
+          "properties": {
+            "address": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "status"
+      ],
+      "properties": {
+        "status": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  ]
+}

--- a/contracts/minters/vending-minter-wl-flex/schema/raw/response_to_config.json
+++ b/contracts/minters/vending-minter-wl-flex/schema/raw/response_to_config.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ConfigResponse",
+  "type": "object",
+  "required": [
+    "admin",
+    "base_token_uri",
+    "factory",
+    "mint_price",
+    "num_tokens",
+    "per_address_limit",
+    "sg721_address",
+    "sg721_code_id",
+    "start_time"
+  ],
+  "properties": {
+    "admin": {
+      "type": "string"
+    },
+    "base_token_uri": {
+      "type": "string"
+    },
+    "discount_price": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Coin"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "factory": {
+      "type": "string"
+    },
+    "mint_price": {
+      "$ref": "#/definitions/Coin"
+    },
+    "num_tokens": {
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0.0
+    },
+    "per_address_limit": {
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0.0
+    },
+    "sg721_address": {
+      "type": "string"
+    },
+    "sg721_code_id": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "start_time": {
+      "$ref": "#/definitions/Timestamp"
+    },
+    "whitelist": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Coin": {
+      "type": "object",
+      "required": [
+        "amount",
+        "denom"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "denom": {
+          "type": "string"
+        }
+      }
+    },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/minters/vending-minter-wl-flex/schema/raw/response_to_mint_count.json
+++ b/contracts/minters/vending-minter-wl-flex/schema/raw/response_to_mint_count.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MintCountResponse",
+  "type": "object",
+  "required": [
+    "address",
+    "count",
+    "whitelist_count"
+  ],
+  "properties": {
+    "address": {
+      "type": "string"
+    },
+    "count": {
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0.0
+    },
+    "whitelist_count": {
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0.0
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/minters/vending-minter-wl-flex/schema/raw/response_to_mint_price.json
+++ b/contracts/minters/vending-minter-wl-flex/schema/raw/response_to_mint_price.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MintPriceResponse",
+  "type": "object",
+  "required": [
+    "airdrop_price",
+    "current_price",
+    "public_price"
+  ],
+  "properties": {
+    "airdrop_price": {
+      "$ref": "#/definitions/Coin"
+    },
+    "current_price": {
+      "$ref": "#/definitions/Coin"
+    },
+    "discount_price": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Coin"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_price": {
+      "$ref": "#/definitions/Coin"
+    },
+    "whitelist_price": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Coin"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Coin": {
+      "type": "object",
+      "required": [
+        "amount",
+        "denom"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "denom": {
+          "type": "string"
+        }
+      }
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/minters/vending-minter-wl-flex/schema/raw/response_to_mintable_num_tokens.json
+++ b/contracts/minters/vending-minter-wl-flex/schema/raw/response_to_mintable_num_tokens.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MintableNumTokensResponse",
+  "type": "object",
+  "required": [
+    "count"
+  ],
+  "properties": {
+    "count": {
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0.0
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/minters/vending-minter-wl-flex/schema/raw/response_to_start_time.json
+++ b/contracts/minters/vending-minter-wl-flex/schema/raw/response_to_start_time.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "StartTimeResponse",
+  "type": "object",
+  "required": [
+    "start_time"
+  ],
+  "properties": {
+    "start_time": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/minters/vending-minter-wl-flex/schema/raw/response_to_status.json
+++ b/contracts/minters/vending-minter-wl-flex/schema/raw/response_to_status.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "StatusResponse",
+  "type": "object",
+  "required": [
+    "status"
+  ],
+  "properties": {
+    "status": {
+      "$ref": "#/definitions/Status"
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Status": {
+      "type": "object",
+      "required": [
+        "is_blocked",
+        "is_explicit",
+        "is_verified"
+      ],
+      "properties": {
+        "is_blocked": {
+          "type": "boolean"
+        },
+        "is_explicit": {
+          "type": "boolean"
+        },
+        "is_verified": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/contracts/minters/vending-minter-wl-flex/schema/vending-minter-wl-flex.json
+++ b/contracts/minters/vending-minter-wl-flex/schema/vending-minter-wl-flex.json
@@ -177,7 +177,7 @@
             "minimum": 0.0
           },
           "min_mint_price": {
-            "$ref": "#/definitions/Coin"
+            "$ref": "#/definitions/Token"
           },
           "mint_fee_bps": {
             "type": "integer",
@@ -243,6 +243,34 @@
         "allOf": [
           {
             "$ref": "#/definitions/Uint64"
+          }
+        ]
+      },
+      "Token": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "fungible"
+            ],
+            "properties": {
+              "fungible": {
+                "$ref": "#/definitions/Coin"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "non_fungible"
+            ],
+            "properties": {
+              "non_fungible": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
           }
         ]
       },

--- a/contracts/minters/vending-minter-wl-flex/src/contract.rs
+++ b/contracts/minters/vending-minter-wl-flex/src/contract.rs
@@ -146,7 +146,8 @@ pub fn instantiate(
             start_time: msg.init_msg.start_time,
             discount_price: None,
         },
-        mint_price: msg.init_msg.mint_price,
+        mint_price: sg2::Fungible(msg.init_msg.mint_price),
+        allowed_burn_collections: Some(vec![]),
     };
 
     CONFIG.save(deps.storage, &config)?;
@@ -244,11 +245,11 @@ pub fn execute_update_discount_price(
     if env.block.time < config.extension.start_time {
         return Err(ContractError::BeforeMintStartTime {});
     }
-
+    let config_mint_price = config.mint_price.clone().amount()?;
     // discount price can't be greater than unit price
-    if price > config.mint_price.amount.u128() {
+    if price > config_mint_price.into() {
         return Err(ContractError::UpdatedMintPriceTooHigh {
-            allowed: config.mint_price.amount.u128(),
+            allowed: config_mint_price.into(),
             updated: price,
         });
     }
@@ -258,14 +259,16 @@ pub fn execute_update_discount_price(
         .query_wasm_smart(config.clone().factory, &Sg2QueryMsg::Params {})?;
     let factory_params = factory.params;
 
-    if factory_params.min_mint_price.amount.u128() > price {
+    let min_mint_price = factory_params.min_mint_price.amount()?;
+
+    if min_mint_price > price.into() {
         return Err(ContractError::InsufficientMintPrice {
-            expected: factory_params.min_mint_price.amount.u128(),
+            expected: min_mint_price.into(),
             got: price,
         });
     }
-
-    config.extension.discount_price = Some(coin(price, config.mint_price.denom.clone()));
+    let config_denom = config.mint_price.clone().denom()?;
+    config.extension.discount_price = Some(coin(price, config_denom));
     CONFIG.save(deps.storage, &config)?;
 
     Ok(Response::new()
@@ -419,12 +422,13 @@ pub fn execute_set_whitelist(
         .querier
         .query_wasm_smart(config.factory.clone(), &Sg2QueryMsg::Params {})?;
 
-    let factory_mint_price = factory.params.min_mint_price.amount.u128();
+    let min_mint_price = factory.params.min_mint_price.amount()?;
+    let factory_mint_price = min_mint_price;
     let whitelist_mint_price = wl_config.mint_price.amount.u128();
 
-    if factory_mint_price > whitelist_mint_price {
+    if factory_mint_price > whitelist_mint_price.into() {
         return Err(ContractError::InsufficientWhitelistMintPrice {
-            expected: factory_mint_price,
+            expected: factory_mint_price.into(),
             got: whitelist_mint_price,
         });
     }
@@ -593,13 +597,18 @@ fn _execute_mint(
         None => info.sender.clone(),
     };
 
-    let mint_price: Coin = mint_price(deps.as_ref(), is_admin)?;
+    let mint_price_with_discounts: Coin = mint_price(deps.as_ref(), is_admin)?;
+    let config_denom = config
+        .mint_price
+        .clone()
+        .denom()
+        .map_err(|_| ContractError::IncorrectFungibility {})?;
     // Exact payment only accepted
-    let payment = may_pay(&info, &config.mint_price.denom)?;
-    if payment != mint_price.amount {
+    let payment = may_pay(&info, &config_denom)?;
+    if payment != mint_price_with_discounts.amount {
         return Err(ContractError::IncorrectPaymentAmount(
-            coin(payment.u128(), &config.mint_price.denom),
-            mint_price,
+            coin(payment.u128(), &config_denom),
+            mint_price_with_discounts,
         ));
     }
 
@@ -619,7 +628,7 @@ fn _execute_mint(
     } else {
         factory_params.mint_fee_bps.bps_to_decimal()
     };
-    let network_fee = mint_price.amount * mint_fee;
+    let network_fee = mint_price_with_discounts.amount * mint_fee;
     checked_fair_burn(&info, network_fee.u128(), None, &mut res)?;
 
     let mintable_token_mapping = match token_id {
@@ -676,14 +685,14 @@ fn _execute_mint(
     }
 
     let seller_amount = if !is_admin {
-        let amount = mint_price.amount - network_fee;
+        let amount = mint_price_with_discounts.amount - network_fee;
         let payment_address = config.extension.payment_address;
         let seller = config.extension.admin;
         // Sending 0 coins fails, so only send if amount is non-zero
         if !amount.is_zero() {
             let msg = BankMsg::Send {
                 to_address: payment_address.unwrap_or(seller).to_string(),
-                amount: vec![coin(amount.u128(), mint_price.denom)],
+                amount: vec![coin(amount.u128(), mint_price_with_discounts.denom)],
             };
             res = res.add_message(msg);
         }
@@ -698,7 +707,7 @@ fn _execute_mint(
         .add_attribute("recipient", recipient_addr)
         .add_attribute("token_id", mintable_token_mapping.token_id.to_string())
         .add_attribute("network_fee", network_fee)
-        .add_attribute("mint_price", mint_price.amount)
+        .add_attribute("mint_price", mint_price_with_discounts.amount)
         .add_attribute("seller_amount", seller_amount))
 }
 
@@ -779,10 +788,12 @@ pub fn execute_update_mint_price(
             "Sender is not an admin".to_owned(),
         ));
     }
+    let config_mint_price = config.mint_price.clone().amount()?;
+
     // If current time is after the stored start time, only allow lowering price
-    if env.block.time >= config.extension.start_time && price >= config.mint_price.amount.u128() {
+    if env.block.time >= config.extension.start_time && price >= config_mint_price.into() {
         return Err(ContractError::UpdatedMintPriceTooHigh {
-            allowed: config.mint_price.amount.u128(),
+            allowed: config_mint_price.into(),
             updated: price,
         });
     }
@@ -792,14 +803,22 @@ pub fn execute_update_mint_price(
         .query_wasm_smart(config.clone().factory, &Sg2QueryMsg::Params {})?;
     let factory_params = factory.params;
 
-    if factory_params.min_mint_price.amount.u128() > price {
+    let min_mint_price = factory_params.min_mint_price.amount()?;
+
+    if min_mint_price > price.into() {
         return Err(ContractError::InsufficientMintPrice {
-            expected: factory_params.min_mint_price.amount.u128(),
+            expected: min_mint_price.into(),
             got: price,
         });
     }
 
-    config.mint_price = coin(price, config.mint_price.denom);
+    let config_denom = config
+        .mint_price
+        .clone()
+        .denom()
+        .map_err(|_| ContractError::IncorrectFungibility {})?;
+
+    config.mint_price = sg2::Fungible(coin(price, config_denom));
     CONFIG.save(deps.storage, &config)?;
     Ok(Response::new()
         .add_attribute("action", "update_mint_price")
@@ -985,15 +1004,22 @@ pub fn mint_price(deps: Deps, is_admin: bool) -> Result<Coin, StdError> {
         .query_wasm_smart(config.factory, &Sg2QueryMsg::Params {})?;
     let factory_params = factory.params;
 
+    let config_fungible_coin = coin(
+        config.mint_price.clone().amount()?.into(),
+        config.mint_price.denom()?,
+    );
     if is_admin {
         return Ok(coin(
             factory_params.extension.airdrop_mint_price.amount.u128(),
-            config.mint_price.denom,
+            config_fungible_coin.denom,
         ));
     }
 
     if config.extension.whitelist.is_none() {
-        let price = config.extension.discount_price.unwrap_or(config.mint_price);
+        let price = config
+            .extension
+            .discount_price
+            .unwrap_or(config_fungible_coin);
         return Ok(price);
     }
 
@@ -1006,7 +1032,10 @@ pub fn mint_price(deps: Deps, is_admin: bool) -> Result<Coin, StdError> {
     if wl_config.is_active {
         Ok(wl_config.mint_price)
     } else {
-        let price = config.extension.discount_price.unwrap_or(config.mint_price);
+        let price = config
+            .extension
+            .discount_price
+            .unwrap_or(config_fungible_coin);
         Ok(price)
     }
 }
@@ -1077,6 +1106,11 @@ fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
     let config = CONFIG.load(deps.storage)?;
     let sg721_address = SG721_ADDRESS.load(deps.storage)?;
 
+    let config_fungible_coin = coin(
+        config.mint_price.clone().amount()?.into(),
+        config.mint_price.denom()?,
+    );
+
     Ok(ConfigResponse {
         admin: config.extension.admin.to_string(),
         base_token_uri: config.extension.base_token_uri,
@@ -1084,7 +1118,7 @@ fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
         sg721_code_id: config.collection_code_id,
         num_tokens: config.extension.num_tokens,
         start_time: config.extension.start_time,
-        mint_price: config.mint_price,
+        mint_price: config_fungible_coin,
         per_address_limit: config.extension.per_address_limit,
         whitelist: config.extension.whitelist.map(|w| w.to_string()),
         factory: config.factory.to_string(),
@@ -1130,9 +1164,11 @@ fn query_mint_price(deps: Deps) -> StdResult<MintPriceResponse> {
         .query_wasm_smart(config.factory, &Sg2QueryMsg::Params {})?;
 
     let factory_params = factory.params;
+    let config_mint_price = config.mint_price.clone().amount()?;
+    let config_denom = config.mint_price.denom()?;
 
     let current_price = mint_price(deps, false)?;
-    let public_price = config.mint_price.clone();
+    let public_price = config_mint_price;
     let whitelist_price: Option<Coin> = if let Some(whitelist) = config.extension.whitelist {
         let wl_config: WhitelistConfigResponse = deps
             .querier
@@ -1143,11 +1179,11 @@ fn query_mint_price(deps: Deps) -> StdResult<MintPriceResponse> {
     };
     let airdrop_price = coin(
         factory_params.extension.airdrop_mint_price.amount.u128(),
-        config.mint_price.denom,
+        config_denom.clone(),
     );
     let discount_price = config.extension.discount_price;
     Ok(MintPriceResponse {
-        public_price,
+        public_price: coin(public_price.u128(), config_denom),
         airdrop_price,
         whitelist_price,
         current_price,

--- a/contracts/minters/vending-minter-wl-flex/src/error.rs
+++ b/contracts/minters/vending-minter-wl-flex/src/error.rs
@@ -3,6 +3,7 @@ use cw_utils::PaymentError;
 use sg1::FeeError;
 use thiserror::Error;
 use url::ParseError;
+
 #[derive(Error, Debug, PartialEq)]
 pub enum ContractError {
     #[error("{0}")]
@@ -103,4 +104,7 @@ pub enum ContractError {
 
     #[error("Multiply Fraction Error")]
     CheckedMultiplyFractionError {},
+
+    #[error("Expected fungible token, received nonfungible")]
+    IncorrectFungibility {},
 }

--- a/contracts/minters/vending-minter/Cargo.toml
+++ b/contracts/minters/vending-minter/Cargo.toml
@@ -51,4 +51,6 @@ sg-whitelist    = { workspace = true, features = ["library"] }
 thiserror       = { workspace = true }
 url             = { workspace = true }
 vending-factory = { workspace = true, features = ["library"] }
-semver           = {workspace = true  }
+semver          = {workspace = true  }
+burn-to-mint    = { workspace = true }
+sg-controllers  = { workspace = true }

--- a/contracts/minters/vending-minter/schema/execute_msg.json
+++ b/contracts/minters/vending-minter/schema/execute_msg.json
@@ -236,9 +236,46 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "receive_nft"
+      ],
+      "properties": {
+        "receive_nft": {
+          "$ref": "#/definitions/Cw721ReceiveMsg"
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {
+    "Binary": {
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+      "type": "string"
+    },
+    "Cw721ReceiveMsg": {
+      "description": "Cw721ReceiveMsg should be de/serialized under `Receive()` variant in a ExecuteMsg",
+      "type": "object",
+      "required": [
+        "msg",
+        "sender",
+        "token_id"
+      ],
+      "properties": {
+        "msg": {
+          "$ref": "#/definitions/Binary"
+        },
+        "sender": {
+          "type": "string"
+        },
+        "token_id": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
     "Timestamp": {
       "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
       "allOf": [

--- a/contracts/minters/vending-minter/schema/instantiate_msg.json
+++ b/contracts/minters/vending-minter/schema/instantiate_msg.json
@@ -16,6 +16,10 @@
   },
   "additionalProperties": false,
   "definitions": {
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
     "Coin": {
       "type": "object",
       "required": [
@@ -117,6 +121,15 @@
         "init_msg"
       ],
       "properties": {
+        "allowed_burn_collections": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Addr"
+          }
+        },
         "collection_params": {
           "$ref": "#/definitions/CollectionParams"
         },
@@ -173,7 +186,7 @@
           "minimum": 0.0
         },
         "min_mint_price": {
-          "$ref": "#/definitions/Coin"
+          "$ref": "#/definitions/Token"
         },
         "mint_fee_bps": {
           "type": "integer",
@@ -239,6 +252,34 @@
       "allOf": [
         {
           "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Token": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "fungible"
+          ],
+          "properties": {
+            "fungible": {
+              "$ref": "#/definitions/Coin"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "non_fungible"
+          ],
+          "properties": {
+            "non_fungible": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
         }
       ]
     },

--- a/contracts/minters/vending-minter/schema/minter_config_for__config_extension.json
+++ b/contracts/minters/vending-minter/schema/minter_config_for__config_extension.json
@@ -10,6 +10,15 @@
     "mint_price"
   ],
   "properties": {
+    "allowed_burn_collections": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/Addr"
+      }
+    },
     "collection_code_id": {
       "type": "integer",
       "format": "uint64",
@@ -22,7 +31,7 @@
       "$ref": "#/definitions/Addr"
     },
     "mint_price": {
-      "$ref": "#/definitions/Coin"
+      "$ref": "#/definitions/Token"
     }
   },
   "additionalProperties": false,
@@ -113,6 +122,34 @@
       "allOf": [
         {
           "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Token": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "fungible"
+          ],
+          "properties": {
+            "fungible": {
+              "$ref": "#/definitions/Coin"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "non_fungible"
+          ],
+          "properties": {
+            "non_fungible": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
         }
       ]
     },

--- a/contracts/minters/vending-minter/src/error.rs
+++ b/contracts/minters/vending-minter/src/error.rs
@@ -3,6 +3,7 @@ use cw_utils::PaymentError;
 use sg1::FeeError;
 use thiserror::Error;
 use url::ParseError;
+
 #[derive(Error, Debug, PartialEq)]
 pub enum ContractError {
     #[error("{0}")]
@@ -103,4 +104,10 @@ pub enum ContractError {
 
     #[error("Multiply Fraction Error")]
     CheckedMultiplyFractionError {},
+
+    #[error("Expected fungible token, received nonfungible")]
+    IncorrectFungibility {},
+
+    #[error("Burn to Mint Error")]
+    BurnToMintError {},
 }

--- a/contracts/minters/vending-minter/src/msg.rs
+++ b/contracts/minters/vending-minter/src/msg.rs
@@ -1,5 +1,6 @@
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Coin, Timestamp};
+use cw721::Cw721ReceiveMsg;
 use vending_factory::{msg::VendingMinterCreateMsg, state::VendingMinterParams};
 
 #[cw_serde]
@@ -37,6 +38,7 @@ pub enum ExecuteMsg {
         price: u128,
     },
     RemoveDiscountPrice {},
+    ReceiveNft(Cw721ReceiveMsg),
 }
 
 #[cw_serde]

--- a/e2e/src/helpers/helper.rs
+++ b/e2e/src/helpers/helper.rs
@@ -44,10 +44,10 @@ pub fn instantiate_factory(
                     amount: Uint128::new(CREATION_FEE),
                     denom: denom.to_string(),
                 },
-                min_mint_price: Coin {
+                min_mint_price: sg2::Fungible(Coin {
                     amount: Uint128::new(50),
                     denom: denom.to_string(),
-                },
+                }),
                 mint_fee_bps: 1000, // 10%
                 max_trading_offset_secs: (60 * 60) * 24,
                 extension: ParamsExtension {
@@ -108,6 +108,7 @@ pub fn create_minter_msg(
                 royalty_info: None,
             },
         },
+        allowed_burn_collections: None,
     }
 }
 

--- a/e2e/src/helpers/open_edition_minter_helpers.rs
+++ b/e2e/src/helpers/open_edition_minter_helpers.rs
@@ -48,10 +48,10 @@ pub fn instantiate_factory(
                     amount: Uint128::new(CREATION_FEE),
                     denom: denom.to_string(),
                 },
-                min_mint_price: Coin {
+                min_mint_price: sg2::Fungible(Coin {
                     amount: Uint128::new(50),
                     denom: denom.to_string(),
-                },
+                }),
                 mint_fee_bps: 1000, // 10%
                 max_trading_offset_secs: (60 * 60) * 24,
                 extension: ParamsExtension {
@@ -111,5 +111,6 @@ pub fn create_minter_msg(
                 royalty_info: None,
             },
         },
+        allowed_burn_collections: None,
     }
 }

--- a/packages/burn-to-mint/Cargo.toml
+++ b/packages/burn-to-mint/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "burn-to-mint"
+authors = ["Michael Scotto <m@publicawsome.com>"]
+description = "Burn to mint utility functions"
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
+
+exclude = [
+    # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+    "contract.wasm",
+    "hash.txt",
+]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+cosmwasm-schema = { workspace = true }
+cosmwasm-std = { workspace = true, features = ["staking"] }
+base-factory    = { workspace = true }
+cw2             = { workspace = true }
+cw721           = { workspace = true }
+cw721-base      = { workspace = true, features = ["library"] }
+cw-storage-plus = { workspace = true }
+cw-utils        = { workspace = true }
+schemars        = { workspace = true }
+serde           = { workspace = true }
+sg1             = { workspace = true }
+sg2             = { workspace = true }
+sg4             = { workspace = true }
+sg721           = { workspace = true }
+sg721-base      = { workspace = true, features = ["library"] }
+sg-std          = { workspace = true }
+thiserror       = { workspace = true }
+url             = { workspace = true }

--- a/packages/burn-to-mint/src/lib.rs
+++ b/packages/burn-to-mint/src/lib.rs
@@ -1,0 +1,59 @@
+use cosmwasm_std::{Addr, StdError};
+pub mod msg;
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::{to_binary, CosmosMsg, MessageInfo, WasmMsg};
+
+use cw721::Cw721ReceiveMsg;
+use sg_std::Response;
+
+pub fn generate_burn_msg(
+    info: MessageInfo,
+    msg: Cw721ReceiveMsg,
+    contract_addr: Addr,
+) -> Result<Response, StdError> {
+    let res = Response::new();
+    let burn_msg = cw721::Cw721ExecuteMsg::Burn {
+        token_id: msg.token_id.clone(),
+    };
+    let cosmos_burn_msg = CosmosMsg::Wasm(WasmMsg::Execute {
+        contract_addr: info.sender.to_string(),
+        msg: to_binary(&burn_msg)?,
+        funds: vec![],
+    });
+    // let res = res.add_attribute("sender", info.sender);
+    // let res = res.add_attribute("token_id", msg.token_id);
+    // let res = res.add_attribute("contract_address", contract_addr);
+    // Ok(res.add_message(cosmos_burn_msg))
+    Ok(res
+        .add_attribute("sender", info.sender)
+        .add_attribute("token_id", msg.token_id)
+        .add_attribute("contract_address", contract_addr)
+        .add_message(cosmos_burn_msg))
+}
+
+pub fn check_sender_creator_or_allowed_burn_collection(
+    info: MessageInfo,
+    creator_addr: Addr,
+    allowed_burn_collections: Option<Vec<Addr>>,
+) -> Result<bool, StdError> {
+    let mut allowed_senders = vec![creator_addr];
+    if let Some(mut allowed_burn_collections) = allowed_burn_collections {
+        allowed_senders.append(&mut allowed_burn_collections);
+    };
+    if !allowed_senders.contains(&info.sender) {
+        return Err(StdError::GenericErr {
+            msg: "Sender is not sg721 creator".to_string(),
+        });
+    }
+    Ok(true)
+}
+
+pub fn sender_is_allowed_burn_collection(
+    info: MessageInfo,
+    allowed_burn_collections: Option<Vec<Addr>>,
+) -> bool {
+    if let Some(allowed_burn_collections) = allowed_burn_collections {
+        return allowed_burn_collections.contains(&info.sender);
+    };
+    false
+}

--- a/packages/burn-to-mint/src/msg.rs
+++ b/packages/burn-to-mint/src/msg.rs
@@ -1,0 +1,6 @@
+use cosmwasm_schema::cw_serde;
+
+#[cw_serde]
+pub struct TokenUriMsg {
+    pub token_uri: String,
+}

--- a/packages/controllers/src/lib.rs
+++ b/packages/controllers/src/lib.rs
@@ -1,5 +1,7 @@
 mod hooks;
 mod init;
+mod minter;
 
 pub use hooks::{HookError, Hooks, HooksResponse};
 pub use init::{Admin, ContractInstantiateMsg};
+pub use minter::{compute_seller_amount, pay_mint};

--- a/packages/controllers/src/minter.rs
+++ b/packages/controllers/src/minter.rs
@@ -1,0 +1,47 @@
+use cosmwasm_std::{coin, BankMsg, Coin, MessageInfo, Uint128};
+use cosmwasm_std::{Addr, StdError};
+use cw_utils::may_pay;
+use sg_std::Response;
+
+pub fn compute_seller_amount(
+    mut res: Response,
+    mint_price_with_discounts: Coin,
+    network_fee: Uint128,
+    payment_address: Option<Addr>,
+    admin: Addr,
+) -> Result<(Response, Uint128), StdError> {
+    let seller_amount = {
+        // the net amount is mint price - network fee (mint free + dev fee)
+        let amount = mint_price_with_discounts.amount.checked_sub(network_fee)?;
+        let payment_address = payment_address;
+        let seller = admin;
+        // Sending 0 coins fails, so only send if amount is non-zero
+        if !amount.is_zero() {
+            let msg = BankMsg::Send {
+                to_address: payment_address.unwrap_or(seller).to_string(),
+                amount: vec![coin(amount.u128(), mint_price_with_discounts.denom)],
+            };
+            res = res.clone().add_message(msg);
+        }
+        amount
+    };
+    Ok((res, seller_amount))
+}
+
+pub fn pay_mint(
+    info: MessageInfo,
+    mint_price_with_discounts: Coin,
+    config_denom: String,
+) -> Result<Uint128, StdError> {
+    let payment =
+        may_pay(&info, &config_denom).map_err(|e| StdError::GenericErr { msg: e.to_string() })?;
+    if payment != mint_price_with_discounts.amount {
+        let err_msg = format!(
+            "IncorrectPaymentAmount {0} != {1}",
+            coin(payment.u128(), &config_denom),
+            mint_price_with_discounts,
+        );
+        return Err(StdError::GenericErr { msg: err_msg });
+    }
+    Ok(payment)
+}

--- a/packages/sg2/src/error.rs
+++ b/packages/sg2/src/error.rs
@@ -1,0 +1,10 @@
+use thiserror::Error;
+
+// [FIMXE]: remove as this is not a contract and shouldn't have contract errors
+// `StdError` is used for library errors
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ContractError {
+    #[error("Expected fungible token, received nonfungible")]
+    IncorrectFungibility {},
+}

--- a/packages/sg2/src/lib.rs
+++ b/packages/sg2/src/lib.rs
@@ -1,11 +1,53 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::Coin;
+use cosmwasm_std::{coin, Coin, StdError, Uint128};
 
+pub mod error;
 pub mod msg;
 pub mod query;
 pub mod tests;
 
 pub type CodeId = u64;
+pub use Token::{Fungible, NonFungible};
+
+#[cw_serde]
+pub enum Token {
+    Fungible(Coin),
+    NonFungible(String),
+}
+
+impl Token {
+    pub fn new_fungible_token(amount: u128, denom: String) -> Token {
+        Token::Fungible(coin(amount, denom))
+    }
+
+    pub fn denom(self) -> Result<String, StdError> {
+        let denom = match self {
+            Token::Fungible(coin) => coin.denom,
+            Token::NonFungible(_) => {
+                return Err(StdError::generic_err("non-fungible tokens have no denom"))
+            }
+        };
+        Ok(denom)
+    }
+
+    /// A nice helper that can be used to check if its fungible or not
+    pub fn is_fungible(self) -> bool {
+        match self {
+            Token::Fungible(_) => true,
+            Token::NonFungible(_) => false,
+        }
+    }
+
+    pub fn amount(self) -> Result<Uint128, StdError> {
+        let amount = match self {
+            Token::Fungible(coin) => coin.amount,
+            Token::NonFungible(_) => {
+                return Err(StdError::generic_err("non-fungible tokens have no amount"))
+            }
+        };
+        Ok(amount)
+    }
+}
 
 /// Common params for all minters used for storage
 #[cw_serde]
@@ -15,7 +57,7 @@ pub struct MinterParams<T> {
     pub allowed_sg721_code_ids: Vec<CodeId>,
     pub frozen: bool,
     pub creation_fee: Coin,
-    pub min_mint_price: Coin,
+    pub min_mint_price: Token,
     pub mint_fee_bps: u64,
     pub max_trading_offset_secs: u64,
     pub extension: T,

--- a/packages/sg2/src/msg.rs
+++ b/packages/sg2/src/msg.rs
@@ -1,11 +1,14 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::Coin;
+use cosmwasm_std::{Addr, Coin};
 use sg721::{CollectionInfo, RoyaltyInfoResponse};
+
+use crate::Token;
 
 #[cw_serde]
 pub struct CreateMinterMsg<T> {
     pub init_msg: T,
     pub collection_params: CollectionParams,
+    pub allowed_burn_collections: Option<Vec<Addr>>,
 }
 
 #[cw_serde]
@@ -26,7 +29,7 @@ pub struct UpdateMinterParamsMsg<T> {
     pub rm_sg721_code_ids: Option<Vec<u64>>,
     pub frozen: Option<bool>,
     pub creation_fee: Option<Coin>,
-    pub min_mint_price: Option<Coin>,
+    pub min_mint_price: Option<Token>,
     pub mint_fee_bps: Option<u64>,
     pub max_trading_offset_secs: Option<u64>,
     pub extension: T,

--- a/packages/sg4/Cargo.toml
+++ b/packages/sg4/Cargo.toml
@@ -13,4 +13,5 @@ cosmwasm-schema = { workspace = true }
 cosmwasm-std    = { workspace = true }
 schemars        = { workspace = true }
 serde           = { workspace = true }
+sg2             = { workspace = true }
 thiserror       = { workspace = true }

--- a/packages/sg4/src/lib.rs
+++ b/packages/sg4/src/lib.rs
@@ -1,13 +1,15 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, Coin};
+use cosmwasm_std::Addr;
+use sg2::Token;
 
 /// Saved in every minter
 #[cw_serde]
 pub struct MinterConfig<T> {
     pub factory: Addr,
     pub collection_code_id: u64,
-    pub mint_price: Coin,
+    pub mint_price: Token,
     pub extension: T,
+    pub allowed_burn_collections: Option<Vec<Addr>>,
 }
 
 #[cw_serde]

--- a/test-suite/src/base_factory/tests.rs
+++ b/test-suite/src/base_factory/tests.rs
@@ -1,1 +1,2 @@
 mod integration_tests;
+mod sudo_tests;

--- a/test-suite/src/base_factory/tests/sudo_tests.rs
+++ b/test-suite/src/base_factory/tests/sudo_tests.rs
@@ -1,0 +1,66 @@
+use base_factory::msg::ParamsResponse;
+use cosmwasm_std::{coin, Addr};
+use sg_std::NATIVE_DENOM;
+
+use crate::common_setup::msg::MinterCollectionResponse;
+use crate::common_setup::setup_minter::base_minter::setup::sudo_update_params;
+use crate::common_setup::templates::base_minter_with_sudo_update_params_template;
+use sg2::query::Sg2QueryMsg::Params;
+
+#[test]
+fn happy_path_with_params_update() {
+    let vt = base_minter_with_sudo_update_params_template(2);
+    let (mut router, _, _) = (vt.router, vt.accts.creator, vt.accts.buyer);
+    sudo_update_params(&mut router, &vt.collection_response_vec, vt.code_ids, None);
+}
+
+#[test]
+fn sudo_params_update_invalid_nft_collection() {
+    let vt = base_minter_with_sudo_update_params_template(2);
+    let (mut router, _, _) = (vt.router, vt.accts.creator, vt.accts.buyer);
+    let mut response_collection_vec: Vec<MinterCollectionResponse> = vec![];
+    for entry in vt.collection_response_vec {
+        let new_entry = MinterCollectionResponse {
+            minter: entry.minter,
+            collection: Some(Addr::unchecked("fake_address")),
+            factory: entry.factory,
+            error: entry.error,
+        };
+        response_collection_vec.push(new_entry);
+    }
+    let sudo_responses =
+        sudo_update_params(&mut router, &response_collection_vec, vt.code_ids, None);
+    let sudo_response_1 = sudo_responses.first();
+    let err = sudo_response_1.unwrap().as_ref().unwrap_err().to_string();
+    assert_eq!(err, "InvalidCollectionAddress".to_string());
+}
+
+#[test]
+fn sudo_params_update_creation_fee() {
+    let vt = base_minter_with_sudo_update_params_template(2);
+    let (mut router, _, _) = (vt.router, vt.accts.creator, vt.accts.buyer);
+    let collection = vt.collection_response_vec[0].collection.clone().unwrap();
+    let factory = vt.collection_response_vec[0].factory.clone().unwrap();
+    let code_ids = vt.code_ids.clone();
+    use cosmwasm_std::Empty;
+    let update_msg = sg2::msg::UpdateMinterParamsMsg {
+        code_id: Some(code_ids.sg721_code_id),
+        add_sg721_code_ids: None,
+        rm_sg721_code_ids: None,
+        frozen: None,
+        creation_fee: Some(coin(999, NATIVE_DENOM)),
+        min_mint_price: Some(sg2::NonFungible(collection.to_string())),
+        mint_fee_bps: None,
+        max_trading_offset_secs: Some(100),
+        extension: Empty {},
+    };
+    sudo_update_params(
+        &mut router,
+        &vt.collection_response_vec,
+        vt.code_ids,
+        Some(update_msg),
+    );
+
+    let res: ParamsResponse = router.wrap().query_wasm_smart(factory, &Params {}).unwrap();
+    assert_eq!(res.params.creation_fee, coin(999, NATIVE_DENOM));
+}

--- a/test-suite/src/base_minter/tests/integration_tests.rs
+++ b/test-suite/src/base_minter/tests/integration_tests.rs
@@ -4,11 +4,12 @@ use crate::common_setup::setup_minter::base_minter::mock_params::mock_params;
 use crate::common_setup::setup_minter::common::constants::MIN_MINT_PRICE;
 use crate::common_setup::templates::{
     base_minter_with_sg721, base_minter_with_sg721nt, base_minter_with_specified_sg721,
+    base_minter_with_two_sg721_collections_burn_mint,
 };
 use base_factory::msg::{BaseMinterCreateMsg, BaseUpdateParamsMsg, SudoMsg};
 
-use base_minter::msg::{ConfigResponse, ExecuteMsg};
-use cosmwasm_std::{coin, coins, Addr, Timestamp};
+use base_minter::msg::{ConfigResponse, ExecuteMsg, TokenUriMsg};
+use cosmwasm_std::{coin, coins, to_binary, Addr, Timestamp};
 use cw721::{Cw721ExecuteMsg, Cw721QueryMsg, OwnerOfResponse};
 use cw_multi_test::Executor;
 use sg2::msg::Sg2ExecuteMsg;
@@ -72,6 +73,7 @@ fn update_code_id() {
     let mut msg = BaseMinterCreateMsg {
         init_msg: None,
         collection_params,
+        allowed_burn_collections: None,
     };
     msg.collection_params.info.creator = creator.to_string();
     let creation_fee = coins(CREATION_FEE, NATIVE_DENOM);
@@ -135,8 +137,6 @@ fn check_mint() {
         &mint_msg,
         &[coin(MIN_MINT_PRICE, NATIVE_DENOM)],
     );
-
-    println!("res is {res:?}");
     assert!(res.is_ok());
 
     let creator_balances = router.wrap().query_all_balances(creator.clone()).unwrap();
@@ -152,8 +152,9 @@ fn check_mint() {
         .wrap()
         .query_wasm_smart(minter_addr, &QueryMsg::Config {})
         .unwrap();
+    let config_mint_price = res.config.mint_price.amount().unwrap();
     assert_eq!(res.collection_address, "contract2".to_string());
-    assert_eq!(res.config.mint_price.amount.u128(), MIN_MINT_PRICE);
+    assert_eq!(config_mint_price.u128(), MIN_MINT_PRICE);
 
     let query_owner_msg = Cw721QueryMsg::OwnerOf {
         token_id: String::from("1"),
@@ -215,7 +216,6 @@ fn update_start_trading_time() {
         &ExecuteMsg::UpdateStartTradingTime(Some(default_start_trading_time)),
         &[],
     );
-    println!("res is {res:?}");
     assert!(res.is_ok());
 
     // confirm trading start time
@@ -224,4 +224,126 @@ fn update_start_trading_time() {
         .query_wasm_smart(collection_addr, &Sg721QueryMsg::CollectionInfo {})
         .unwrap();
     assert_eq!(res.start_trading_time, Some(default_start_trading_time));
+}
+
+#[test]
+fn check_burns_tokens_when_received() {
+    let allowed_collections_vec = vec![Addr::unchecked("contract2".to_string())];
+    let bmt = base_minter_with_two_sg721_collections_burn_mint(2, allowed_collections_vec);
+    let (mut router, creator) = (bmt.router, bmt.accts.creator);
+    let minter_addr_1 = bmt.collection_response_vec[0].minter.clone().unwrap();
+    let collection_addr_1 = bmt.collection_response_vec[0].collection.clone().unwrap();
+
+    let minter_addr_2 = bmt.collection_response_vec[1].minter.clone().unwrap();
+
+    let token_uri = "ipfs://example".to_string();
+    // Mint one NFT
+    let mint_msg = ExecuteMsg::Mint {
+        token_uri: token_uri.clone(),
+    };
+    let res = router.execute_contract(
+        creator.clone(),
+        minter_addr_1,
+        &mint_msg,
+        &[coin(MIN_MINT_PRICE, NATIVE_DENOM)],
+    );
+
+    assert!(res.is_ok());
+
+    let num_tokens_res: cw721::NumTokensResponse = router
+        .wrap()
+        .query_wasm_smart(collection_addr_1.clone(), &Cw721QueryMsg::NumTokens {})
+        .unwrap();
+    // one token after mint
+    assert_eq!(num_tokens_res.count, 1);
+
+    let token_uri_msg = TokenUriMsg { token_uri };
+    let send_nft = Cw721ExecuteMsg::SendNft {
+        contract: minter_addr_2.to_string(),
+        token_id: 1.to_string(),
+        msg: to_binary(&token_uri_msg).unwrap(),
+    };
+    let res = router.execute_contract(creator, collection_addr_1.clone(), &send_nft, &[]);
+    assert!(res.is_ok());
+
+    let num_tokens_res: cw721::NumTokensResponse = router
+        .wrap()
+        .query_wasm_smart(collection_addr_1, &Cw721QueryMsg::NumTokens {})
+        .unwrap();
+
+    // zero tokens after burn
+    assert_eq!(num_tokens_res.count, 0);
+}
+
+#[test]
+fn check_mints_new_tokens_when_received() {
+    let allowed_collections_vec = vec![Addr::unchecked("contract2".to_string())];
+    let bmt = base_minter_with_two_sg721_collections_burn_mint(2, allowed_collections_vec);
+    let (mut router, creator) = (bmt.router, bmt.accts.creator);
+    let minter_addr_1 = bmt.collection_response_vec[0].minter.clone().unwrap();
+    let collection_addr_1 = bmt.collection_response_vec[0].collection.clone().unwrap();
+    let collection_addr_2 = bmt.collection_response_vec[1].collection.clone().unwrap();
+    let minter_addr_2 = bmt.collection_response_vec[1].minter.clone().unwrap();
+
+    let token_uri = "ipfs://example".to_string();
+    // Mint one NFT
+    let mint_msg = ExecuteMsg::Mint {
+        token_uri: token_uri.clone(),
+    };
+    let res = router.execute_contract(
+        creator.clone(),
+        minter_addr_1,
+        &mint_msg,
+        &[coin(MIN_MINT_PRICE, NATIVE_DENOM)],
+    );
+    assert!(res.is_ok());
+
+    let num_tokens_res: cw721::NumTokensResponse = router
+        .wrap()
+        .query_wasm_smart(collection_addr_1.clone(), &Cw721QueryMsg::NumTokens {})
+        .unwrap();
+    // one token after mint
+    assert_eq!(num_tokens_res.count, 1);
+
+    let res = router.execute_contract(
+        creator.clone(),
+        minter_addr_2.clone(),
+        &mint_msg,
+        &[coin(MIN_MINT_PRICE, NATIVE_DENOM)],
+    );
+    assert!(res.is_ok());
+
+    let num_tokens_res: cw721::NumTokensResponse = router
+        .wrap()
+        .query_wasm_smart(collection_addr_2.clone(), &Cw721QueryMsg::NumTokens {})
+        .unwrap();
+    // one token after mint
+    assert_eq!(num_tokens_res.count, 1);
+
+    let token_uri_msg = TokenUriMsg { token_uri };
+    let send_nft = Cw721ExecuteMsg::SendNft {
+        contract: minter_addr_2.to_string(),
+        token_id: 1.to_string(),
+        msg: to_binary(&token_uri_msg).unwrap(),
+    };
+    let res = router.execute_contract(
+        creator,
+        collection_addr_1.clone(),
+        &send_nft,
+        &[coin(5_000_000_000, NATIVE_DENOM)],
+    );
+    assert!(res.is_ok());
+    let num_tokens_res: cw721::NumTokensResponse = router
+        .wrap()
+        .query_wasm_smart(collection_addr_1, &Cw721QueryMsg::NumTokens {})
+        .unwrap();
+    // one token after mint
+    assert_eq!(num_tokens_res.count, 0);
+
+    let num_tokens_res: cw721::NumTokensResponse = router
+        .wrap()
+        .query_wasm_smart(collection_addr_2, &Cw721QueryMsg::NumTokens {})
+        .unwrap();
+    // one token after mint
+    assert_eq!(num_tokens_res.count, 2);
 }

--- a/test-suite/src/common_setup/msg.rs
+++ b/test-suite/src/common_setup/msg.rs
@@ -1,6 +1,8 @@
 use anyhow::Error;
 use cosmwasm_std::{Addr, Timestamp};
 
+use cosmwasm_std::Uint128;
+use open_edition_factory::state::{OpenEditionMinterParams, ParamsExtension};
 use sg2::msg::CollectionParams;
 use sg_multi_test::StargazeApp;
 use vending_factory::msg::VendingMinterInitMsgExtension;
@@ -16,6 +18,7 @@ pub struct MinterSetupParams<'a> {
     pub factory_code_id: u64,
     pub sg721_code_id: u64,
     pub init_msg: Option<VendingMinterInitMsgExtension>,
+    pub allowed_burn_collections: Option<Vec<Addr>>,
 }
 pub struct MinterCollectionResponse {
     pub minter: Option<Addr>,
@@ -29,6 +32,7 @@ pub struct MinterInstantiateParams {
     pub start_time: Option<Timestamp>,
     pub splits_addr: Option<String>,
     pub init_msg: Option<VendingMinterInitMsgExtension>,
+    pub allowed_burn_collections: Option<Vec<Addr>>,
 }
 
 use cosmwasm_schema::cw_serde;
@@ -48,6 +52,13 @@ pub struct MinterTemplateResponse<T> {
     pub accts: T,
 }
 
+pub struct MinterTemplateResponseCodeIds<T> {
+    pub collection_response_vec: Vec<MinterCollectionResponse>,
+    pub router: StargazeApp,
+    pub accts: T,
+    pub code_ids: CodeIds,
+}
+
 pub struct Accounts {
     pub creator: Addr,
     pub buyer: Addr,
@@ -65,6 +76,8 @@ pub struct OpenEditionMinterSetupParams<'a> {
     pub factory_code_id: u64,
     pub sg721_code_id: u64,
     pub init_msg: Option<OpenEditionMinterInitMsgExtension>,
+    pub allowed_burn_collections: Option<Vec<Addr>>,
+    pub custom_params: Option<OpenEditionMinterParams>,
 }
 
 pub struct OpenEditionMinterInstantiateParams {
@@ -73,4 +86,14 @@ pub struct OpenEditionMinterInstantiateParams {
     pub per_address_limit: Option<u32>,
     pub nft_data: Option<NftData>,
     pub init_msg: Option<OpenEditionMinterInitMsgExtension>,
+    pub params_extension: Option<ParamsExtension>,
+    pub allowed_burn_collections: Option<Vec<Addr>>,
+    pub custom_params: Option<OpenEditionMinterParams>,
+}
+
+#[derive(Default)]
+pub struct OpenEditionMinterCustomParams<'a> {
+    pub denom: Option<&'a str>,
+    pub mint_fee_bps: Option<u64>,
+    pub airdrop_mint_price_amount: Option<Uint128>,
 }

--- a/test-suite/src/common_setup/setup_minter/base_minter/mock_params.rs
+++ b/test-suite/src/common_setup/setup_minter/base_minter/mock_params.rs
@@ -10,19 +10,23 @@ const MINT_FEE_BPS: u64 = 10_000; // 100%
 pub fn mock_params() -> BaseMinterParams {
     BaseMinterParams {
         code_id: 1,
-        allowed_sg721_code_ids: vec![3],
+        allowed_sg721_code_ids: vec![1, 2, 3, 4, 5, 6],
         frozen: false,
         creation_fee: coin(CREATION_FEE, NATIVE_DENOM),
-        min_mint_price: coin(MIN_MINT_PRICE, NATIVE_DENOM),
+        min_mint_price: sg2::Fungible(coin(MIN_MINT_PRICE, NATIVE_DENOM)),
         mint_fee_bps: MINT_FEE_BPS,
         max_trading_offset_secs: 60 * 60 * 24 * 7,
         extension: None,
     }
 }
 
-pub fn mock_create_minter(collection_params: CollectionParams) -> BaseMinterCreateMsg {
+pub fn mock_create_minter(
+    collection_params: CollectionParams,
+    allowed_burn_collections: Option<Vec<cosmwasm_std::Addr>>,
+) -> BaseMinterCreateMsg {
     BaseMinterCreateMsg {
         init_msg: None,
         collection_params,
+        allowed_burn_collections,
     }
 }

--- a/test-suite/src/common_setup/setup_minter/base_minter/setup.rs
+++ b/test-suite/src/common_setup/setup_minter/base_minter/setup.rs
@@ -1,11 +1,18 @@
 use crate::common_setup::contract_boxes::contract_base_factory;
 use crate::common_setup::contract_boxes::contract_base_minter;
 use crate::common_setup::contract_boxes::contract_nt_collection;
+use crate::common_setup::contract_boxes::contract_open_edition_factory;
+use crate::common_setup::contract_boxes::contract_open_edition_minter;
 use crate::common_setup::contract_boxes::contract_sg721_base;
 use crate::common_setup::msg::MinterCollectionResponse;
 use crate::common_setup::msg::MinterSetupParams;
 use crate::common_setup::setup_minter::common::parse_response::build_collection_response;
+use anyhow::Error;
+use cosmwasm_std::coin;
+use cosmwasm_std::to_binary;
+use cosmwasm_std::Empty;
 use cosmwasm_std::{coins, Addr};
+use cw_multi_test::AppResponse;
 use cw_multi_test::Executor;
 use sg2::msg::{CollectionParams, Sg2ExecuteMsg};
 use sg_multi_test::StargazeApp;
@@ -49,6 +56,22 @@ pub fn base_minter_sg721_collection_code_ids(router: &mut StargazeApp) -> CodeId
     }
 }
 
+pub fn open_edition_minter_sg721_collection_code_ids(router: &mut StargazeApp) -> CodeIds {
+    let minter_code_id = router.store_code(contract_open_edition_minter());
+    println!("open_edition_minter_code_id: {}", minter_code_id);
+
+    let factory_code_id = router.store_code(contract_open_edition_factory());
+    println!("open_edition_factory_code_id: {}", factory_code_id);
+
+    let sg721_code_id = router.store_code(contract_sg721_base());
+    println!("sg721_code_id: {}", sg721_code_id);
+    CodeIds {
+        minter_code_id,
+        factory_code_id,
+        sg721_code_id,
+    }
+}
+
 // Upload contract code and instantiate minter contract
 pub fn setup_minter_contract(setup_params: MinterSetupParams) -> MinterCollectionResponse {
     let minter_code_id = setup_params.minter_code_id;
@@ -57,6 +80,7 @@ pub fn setup_minter_contract(setup_params: MinterSetupParams) -> MinterCollectio
     let sg721_code_id = setup_params.sg721_code_id;
     let minter_admin = setup_params.minter_admin;
     let collection_params = setup_params.collection_params;
+    let allowed_burn_collections = setup_params.allowed_burn_collections;
 
     let mut params = mock_params();
     params.code_id = minter_code_id;
@@ -72,7 +96,7 @@ pub fn setup_minter_contract(setup_params: MinterSetupParams) -> MinterCollectio
         )
         .unwrap();
 
-    let mut msg = mock_create_minter(collection_params);
+    let mut msg = mock_create_minter(collection_params, allowed_burn_collections);
     msg.collection_params.code_id = sg721_code_id;
     msg.collection_params.info.creator = minter_admin.to_string();
     let creation_fee = coins(CREATION_FEE, NATIVE_DENOM);
@@ -80,6 +104,41 @@ pub fn setup_minter_contract(setup_params: MinterSetupParams) -> MinterCollectio
 
     let res = router.execute_contract(minter_admin, factory_addr.clone(), &msg, &creation_fee);
     build_collection_response(res, factory_addr)
+}
+
+pub fn sudo_update_params(
+    app: &mut StargazeApp,
+    collection_responses: &Vec<MinterCollectionResponse>,
+    code_ids: CodeIds,
+    update_msg: Option<sg2::msg::UpdateMinterParamsMsg<Empty>>,
+) -> Vec<Result<AppResponse, anyhow::Error>> {
+    let mut sudo_responses: Vec<Result<AppResponse, Error>> = vec![];
+    for collection_response in collection_responses {
+        let collection = collection_response.collection.clone().unwrap().to_string();
+
+        let update_msg = match update_msg.clone() {
+            Some(some_update_message) => some_update_message,
+            None => sg2::msg::UpdateMinterParamsMsg {
+                code_id: Some(code_ids.sg721_code_id),
+                add_sg721_code_ids: None,
+                rm_sg721_code_ids: None,
+                frozen: None,
+                creation_fee: Some(coin(0, NATIVE_DENOM)),
+                min_mint_price: Some(sg2::NonFungible(collection)),
+                mint_fee_bps: None,
+                max_trading_offset_secs: Some(100),
+                extension: Empty {},
+            },
+        };
+        let sudo_update_msg = base_factory::msg::SudoMsg::UpdateParams(Box::new(update_msg));
+
+        let sudo_res = app.sudo(cw_multi_test::SudoMsg::Wasm(cw_multi_test::WasmSudo {
+            contract_addr: collection_response.factory.clone().unwrap(),
+            msg: to_binary(&sudo_update_msg).unwrap(),
+        }));
+        sudo_responses.push(sudo_res);
+    }
+    sudo_responses
 }
 
 pub fn configure_base_minter(
@@ -102,6 +161,9 @@ pub fn configure_base_minter(
             sg721_code_id: code_ids.sg721_code_id,
             start_time: minter_instantiate_params_vec[index].start_time,
             init_msg: minter_instantiate_params_vec[index].init_msg.clone(),
+            allowed_burn_collections: minter_instantiate_params_vec[index]
+                .allowed_burn_collections
+                .clone(),
         };
         let minter_collection_res = setup_minter_contract(setup_params);
         minter_collection_info.push(minter_collection_res);

--- a/test-suite/src/common_setup/setup_minter/common/minter_params.rs
+++ b/test-suite/src/common_setup/setup_minter/common/minter_params.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::Timestamp;
+use cosmwasm_std::{Addr, Timestamp};
 use vending_factory::msg::VendingMinterInitMsgExtension;
 
 use crate::common_setup::msg::MinterInstantiateParams;
@@ -8,12 +8,14 @@ pub fn minter_params_all(
     splits_addr: Option<String>,
     start_time: Option<Timestamp>,
     init_msg: Option<VendingMinterInitMsgExtension>,
+    allowed_burn_collections: Option<Vec<Addr>>,
 ) -> MinterInstantiateParams {
     MinterInstantiateParams {
         num_tokens,
         splits_addr,
         start_time,
         init_msg,
+        allowed_burn_collections,
     }
 }
 
@@ -23,5 +25,19 @@ pub fn minter_params_token(num_tokens: u32) -> MinterInstantiateParams {
         splits_addr: None,
         start_time: None,
         init_msg: None,
+        allowed_burn_collections: None,
+    }
+}
+
+pub fn minter_params_allowed_burn_collections(
+    num_tokens: u32,
+    allowed_burn_collections: Vec<Addr>,
+) -> MinterInstantiateParams {
+    MinterInstantiateParams {
+        num_tokens,
+        splits_addr: None,
+        start_time: None,
+        init_msg: None,
+        allowed_burn_collections: Some(allowed_burn_collections),
     }
 }

--- a/test-suite/src/common_setup/setup_minter/open_edition_minter.rs
+++ b/test-suite/src/common_setup/setup_minter/open_edition_minter.rs
@@ -1,2 +1,3 @@
+pub mod minter_params;
 pub mod mock_params;
 pub mod setup;

--- a/test-suite/src/common_setup/setup_minter/open_edition_minter/minter_params.rs
+++ b/test-suite/src/common_setup/setup_minter/open_edition_minter/minter_params.rs
@@ -1,0 +1,79 @@
+use cosmwasm_std::{Addr, Coin, Timestamp, Uint128};
+use open_edition_factory::{
+    msg::OpenEditionMinterInitMsgExtension,
+    state::{OpenEditionMinterParams, ParamsExtension},
+    types::{NftData, NftMetadataType},
+};
+use sg_std::{GENESIS_MINT_START_TIME, NATIVE_DENOM};
+
+use super::mock_params::mock_init_minter_extension;
+use crate::common_setup::{
+    msg::OpenEditionMinterInstantiateParams,
+    setup_minter::common::constants::MIN_MINT_PRICE_OPEN_EDITION,
+};
+
+pub fn minter_params_open_edition(
+    params_extension: ParamsExtension,
+    init_msg: OpenEditionMinterInitMsgExtension,
+    start_time: Option<Timestamp>,
+    end_time: Option<Timestamp>,
+    nft_data: Option<NftData>,
+    allowed_burn_collections: Option<Vec<Addr>>,
+    custom_params: Option<OpenEditionMinterParams>,
+) -> OpenEditionMinterInstantiateParams {
+    let start_time = start_time.unwrap_or(Timestamp::from_nanos(GENESIS_MINT_START_TIME + 100));
+    let end_time = end_time.unwrap_or(Timestamp::from_nanos(GENESIS_MINT_START_TIME + 10_000));
+
+    OpenEditionMinterInstantiateParams {
+        start_time: Some(start_time),
+        end_time: Some(end_time),
+        per_address_limit: Some(init_msg.per_address_limit),
+        nft_data: Some(
+            nft_data.unwrap_or(NftData {
+                nft_data_type: NftMetadataType::OffChainMetadata,
+                extension: None,
+                token_uri: Some(
+                    "ipfs://bafybeiavall5udkxkdtdm4djezoxrmfc6o5fn2ug3ymrlvibvwmwydgrkm/1.jpg"
+                        .to_string(),
+                ),
+            }),
+        ),
+        init_msg: Some(init_msg),
+        params_extension: Some(params_extension),
+        allowed_burn_collections,
+        custom_params,
+    }
+}
+
+pub fn default_nft_data() -> NftData {
+    NftData {
+        nft_data_type: NftMetadataType::OffChainMetadata,
+        extension: None,
+        token_uri: Some(
+            "ipfs://bafybeiavall5udkxkdtdm4djezoxrmfc6o5fn2ug3ymrlvibvwmwydgrkm/1.jpg".to_string(),
+        ),
+    }
+}
+
+pub fn init_msg(
+    nft_data: NftData,
+    per_address_limit_minter: Option<u32>,
+    start_time: Option<Timestamp>,
+    end_time: Option<Timestamp>,
+    mint_price: Option<Coin>,
+) -> OpenEditionMinterInitMsgExtension {
+    let start_time = start_time.unwrap_or(Timestamp::from_nanos(GENESIS_MINT_START_TIME + 100));
+    let end_time = end_time.unwrap_or(Timestamp::from_nanos(GENESIS_MINT_START_TIME + 10_000));
+    let mint_price = mint_price.unwrap_or(Coin {
+        denom: NATIVE_DENOM.to_string(),
+        amount: Uint128::new(MIN_MINT_PRICE_OPEN_EDITION),
+    });
+    mock_init_minter_extension(
+        Some(start_time),
+        Some(end_time),
+        per_address_limit_minter,
+        Some(mint_price),
+        nft_data,
+        None,
+    )
+}

--- a/test-suite/src/common_setup/setup_minter/open_edition_minter/mock_params.rs
+++ b/test-suite/src/common_setup/setup_minter/open_edition_minter/mock_params.rs
@@ -1,16 +1,17 @@
-use cosmwasm_std::{coin, Coin, Timestamp, Uint128};
+use cosmwasm_std::{coin, Addr, Coin, Timestamp, Uint128};
 use open_edition_factory::types::NftData;
 use open_edition_factory::{
     msg::{OpenEditionMinterCreateMsg, OpenEditionMinterInitMsgExtension},
     state::{OpenEditionMinterParams, ParamsExtension},
 };
 use sg2::msg::CollectionParams;
+use sg2::Token;
 use sg_std::{GENESIS_MINT_START_TIME, NATIVE_DENOM};
 
+use crate::common_setup::msg::OpenEditionMinterCustomParams;
 use crate::common_setup::setup_minter::common::constants::{
     CREATION_FEE, DEV_ADDRESS, MINT_FEE_FAIR_BURN, MIN_MINT_PRICE_OPEN_EDITION,
 };
-use crate::common_setup::templates::OpenEditionMinterCustomParams;
 
 pub fn mock_init_minter_extension(
     start_time: Option<Timestamp>,
@@ -23,13 +24,14 @@ pub fn mock_init_minter_extension(
     OpenEditionMinterInitMsgExtension {
         nft_data,
         start_time: start_time.unwrap_or(Timestamp::from_nanos(GENESIS_MINT_START_TIME)),
-        mint_price: mint_price.unwrap_or(coin(MIN_MINT_PRICE_OPEN_EDITION, NATIVE_DENOM)),
+        mint_price: mint_price.unwrap_or_else(|| coin(MIN_MINT_PRICE_OPEN_EDITION, NATIVE_DENOM)),
         per_address_limit: per_address_limit_minter.unwrap_or(1u32),
         end_time: end_time.unwrap_or(Timestamp::from_nanos(GENESIS_MINT_START_TIME + 10_000)),
         payment_address,
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn mock_create_minter(
     start_time: Option<Timestamp>,
     end_time: Option<Timestamp>,
@@ -38,6 +40,7 @@ pub fn mock_create_minter(
     default_nft_data: NftData,
     collection_params: CollectionParams,
     payment_address: Option<String>,
+    allowed_burn_collections: Option<Vec<Addr>>,
 ) -> OpenEditionMinterCreateMsg {
     OpenEditionMinterCreateMsg {
         init_msg: mock_init_minter_extension(
@@ -49,6 +52,7 @@ pub fn mock_create_minter(
             payment_address,
         ),
         collection_params,
+        allowed_burn_collections,
     }
 }
 
@@ -59,9 +63,30 @@ pub fn mock_create_minter_init_msg(
     OpenEditionMinterCreateMsg {
         init_msg,
         collection_params,
+        allowed_burn_collections: None,
     }
 }
 
+pub fn mock_params_proper() -> OpenEditionMinterParams {
+    OpenEditionMinterParams {
+        code_id: 1,
+        allowed_sg721_code_ids: vec![1, 3, 5, 6],
+        frozen: false,
+        creation_fee: coin(CREATION_FEE, NATIVE_DENOM),
+        min_mint_price: sg2::Fungible(coin(MIN_MINT_PRICE_OPEN_EDITION, NATIVE_DENOM)),
+        mint_fee_bps: MINT_FEE_FAIR_BURN,
+        max_trading_offset_secs: 60 * 60 * 24 * 7,
+        extension: ParamsExtension {
+            max_per_address_limit: 10,
+            airdrop_mint_fee_bps: 100,
+            airdrop_mint_price: Coin {
+                denom: NATIVE_DENOM.to_string(),
+                amount: Uint128::new(100_000_000u128),
+            },
+            dev_fee_address: DEV_ADDRESS.to_string(),
+        },
+    }
+}
 // Pass custom params to change minter values
 pub fn mock_params_custom(custom_params: OpenEditionMinterCustomParams) -> OpenEditionMinterParams {
     let denom = custom_params.denom.unwrap_or(NATIVE_DENOM);
@@ -74,7 +99,7 @@ pub fn mock_params_custom(custom_params: OpenEditionMinterCustomParams) -> OpenE
         allowed_sg721_code_ids: vec![1, 3, 5, 6],
         frozen: false,
         creation_fee: coin(CREATION_FEE, NATIVE_DENOM),
-        min_mint_price: coin(MIN_MINT_PRICE_OPEN_EDITION, denom),
+        min_mint_price: sg2::Fungible(coin(MIN_MINT_PRICE_OPEN_EDITION, denom)),
         mint_fee_bps,
         max_trading_offset_secs: 60 * 60 * 24 * 7,
         extension: ParamsExtension {
@@ -84,6 +109,27 @@ pub fn mock_params_custom(custom_params: OpenEditionMinterCustomParams) -> OpenE
                 denom: denom.to_string(),
                 amount: airdrop_mint_price_amount,
             },
+            dev_fee_address: DEV_ADDRESS.to_string(),
+        },
+    }
+}
+
+pub fn mock_params_custom_min_mint_price(
+    min_mint_price: Token,
+    airdrop_mint_price: Coin,
+) -> OpenEditionMinterParams {
+    OpenEditionMinterParams {
+        code_id: 1,
+        allowed_sg721_code_ids: vec![1, 3, 5, 6],
+        frozen: false,
+        creation_fee: coin(CREATION_FEE, NATIVE_DENOM),
+        min_mint_price,
+        mint_fee_bps: MINT_FEE_FAIR_BURN,
+        max_trading_offset_secs: 60 * 60 * 24 * 7,
+        extension: ParamsExtension {
+            max_per_address_limit: 10,
+            airdrop_mint_fee_bps: 100,
+            airdrop_mint_price,
             dev_fee_address: DEV_ADDRESS.to_string(),
         },
     }

--- a/test-suite/src/common_setup/setup_minter/open_edition_minter/setup.rs
+++ b/test-suite/src/common_setup/setup_minter/open_edition_minter/setup.rs
@@ -1,22 +1,24 @@
 use crate::common_setup::contract_boxes::{
-    contract_open_edition_factory, contract_open_edition_minter,
+    contract_open_edition_factory, contract_open_edition_minter, contract_sg721_base,
 };
 use crate::common_setup::msg::{
     MinterCollectionResponse, OpenEditionMinterInstantiateParams, OpenEditionMinterSetupParams,
 };
 use crate::common_setup::setup_minter::common::parse_response::build_collection_response;
-use crate::common_setup::templates::OpenEditionMinterCustomParams;
-use cosmwasm_std::{coins, Addr, Coin, Timestamp};
-use cw_multi_test::{Contract, Executor};
-use open_edition_factory::msg::OpenEditionMinterInitMsgExtension;
+use anyhow::Error;
+use cosmwasm_std::{coin, coins, to_binary, Addr, Coin, Timestamp};
+use cw_multi_test::{AppResponse, Executor};
+use open_edition_factory::msg::{
+    OpenEditionMinterInitMsgExtension, OpenEditionUpdateParamsExtension, OpenEditionUpdateParamsMsg,
+};
 use open_edition_factory::types::NftData;
 use sg2::msg::{CollectionParams, Sg2ExecuteMsg};
 use sg_multi_test::StargazeApp;
-use sg_std::{StargazeMsgWrapper, NATIVE_DENOM};
+use sg_std::NATIVE_DENOM;
 
 use crate::common_setup::msg::CodeIds;
 use crate::common_setup::setup_minter::open_edition_minter::mock_params::{
-    mock_create_minter, mock_init_minter_extension, mock_params_custom,
+    mock_create_minter, mock_init_minter_extension, mock_params_proper,
 };
 
 use crate::common_setup::setup_minter::common::constants::CREATION_FEE;
@@ -57,13 +59,14 @@ pub fn setup_open_edition_minter_contract(
     let end_time = setup_params.end_time;
     let init_msg = setup_params.init_msg.clone();
     let nft_data = setup_params.init_msg.unwrap().nft_data;
+    let allowed_burn_collections = setup_params.allowed_burn_collections;
 
-    let custom_params = OpenEditionMinterCustomParams {
-        denom: None,
-        mint_fee_bps: None,
-        airdrop_mint_price_amount: None,
+    let custom_params = setup_params.custom_params;
+
+    let mut params = mock_params_proper();
+    if let Some(custom_params) = custom_params {
+        params = custom_params;
     };
-    let mut params = mock_params_custom(custom_params);
     params.code_id = minter_code_id;
 
     let factory_addr = router.instantiate_contract(
@@ -76,16 +79,17 @@ pub fn setup_open_edition_minter_contract(
         "factory",
         None,
     );
-
-    let factory_addr = factory_addr.unwrap();
+    let min_mint_price = params.min_mint_price.clone().amount().unwrap();
+    let denom = params.min_mint_price.denom().unwrap();
     let mut msg = mock_create_minter(
         start_time,
         end_time,
-        Some(params.min_mint_price.clone()),
+        Some(coin(min_mint_price.u128(), denom.clone())),
         Some(params.extension.max_per_address_limit),
         nft_data.clone(),
         collection_params,
         None,
+        allowed_burn_collections,
     );
     msg.init_msg = build_init_msg(
         init_msg,
@@ -93,33 +97,83 @@ pub fn setup_open_edition_minter_contract(
         end_time,
         Some(params.extension.max_per_address_limit),
         nft_data,
-        Some(params.min_mint_price),
+        Some(coin(min_mint_price.u128(), denom)),
         None,
     );
     msg.collection_params.code_id = sg721_code_id;
     msg.collection_params.info.creator = minter_admin.to_string();
+
     let creation_fee = coins(CREATION_FEE, NATIVE_DENOM);
     let msg = Sg2ExecuteMsg::CreateMinter(msg);
-
-    let res = router.execute_contract(minter_admin, factory_addr.clone(), &msg, &creation_fee);
-    build_collection_response(res, factory_addr)
+    match factory_addr {
+        Ok(addr) => {
+            let res = router.execute_contract(minter_admin, addr.clone(), &msg, &creation_fee);
+            build_collection_response(res, addr)
+        }
+        Err(e) => MinterCollectionResponse {
+            minter: None,
+            collection: None,
+            factory: None,
+            error: Some(e),
+        },
+    }
 }
 
-pub fn open_edition_minter_code_ids(
-    router: &mut StargazeApp,
-    sg721_code: Box<dyn Contract<StargazeMsgWrapper>>,
-) -> CodeIds {
+pub fn open_edition_minter_code_ids(router: &mut StargazeApp) -> CodeIds {
     let minter_code_id = router.store_code(contract_open_edition_minter());
 
     let factory_code_id = router.store_code(contract_open_edition_factory());
 
-    let sg721_code_id = router.store_code(sg721_code);
+    let sg721_code_id = router.store_code(contract_sg721_base());
 
     CodeIds {
         minter_code_id,
         factory_code_id,
         sg721_code_id,
     }
+}
+
+pub fn sudo_update_params(
+    app: &mut StargazeApp,
+    collection_responses: &Vec<MinterCollectionResponse>,
+    code_ids: CodeIds,
+    update_msg: Option<OpenEditionUpdateParamsMsg>,
+) -> Vec<Result<AppResponse, anyhow::Error>> {
+    let mut sudo_responses: Vec<Result<AppResponse, Error>> = vec![];
+    for collection_response in collection_responses {
+        let collection = collection_response.collection.clone();
+        let collection = collection.unwrap_or(Addr::unchecked("fake"));
+
+        let update_msg = match update_msg.clone() {
+            Some(some_update_message) => some_update_message,
+            None => OpenEditionUpdateParamsMsg {
+                code_id: Some(code_ids.sg721_code_id),
+                add_sg721_code_ids: None,
+                rm_sg721_code_ids: None,
+                frozen: None,
+                creation_fee: Some(coin(0, NATIVE_DENOM)),
+                min_mint_price: Some(sg2::NonFungible(collection.to_string())),
+                mint_fee_bps: None,
+                max_trading_offset_secs: Some(100),
+                extension: OpenEditionUpdateParamsExtension {
+                    min_mint_price: None,
+                    dev_fee_address: None,
+                    max_per_address_limit: None,
+                    airdrop_mint_price: None,
+                    airdrop_mint_fee_bps: None,
+                },
+            },
+        };
+        let sudo_update_msg =
+            open_edition_factory::msg::SudoMsg::UpdateParams(Box::new(update_msg));
+
+        let sudo_res = app.sudo(cw_multi_test::SudoMsg::Wasm(cw_multi_test::WasmSudo {
+            contract_addr: collection_response.factory.clone().unwrap(),
+            msg: to_binary(&sudo_update_msg).unwrap(),
+        }));
+        sudo_responses.push(sudo_res);
+    }
+    sudo_responses
 }
 
 pub fn configure_open_edition_minter(
@@ -149,6 +203,10 @@ pub fn configure_open_edition_minter(
                 .unwrap(),
             init_msg: minter_instantiate_params_vec[index].init_msg.clone(),
             end_time: minter_instantiate_params_vec[index].end_time.to_owned(),
+            allowed_burn_collections: minter_instantiate_params_vec[index]
+                .allowed_burn_collections
+                .clone(),
+            custom_params: minter_instantiate_params_vec[index].custom_params.clone(),
         };
         let minter_collection_res = setup_open_edition_minter_contract(setup_params);
         minter_collection_info.push(minter_collection_res);

--- a/test-suite/src/common_setup/setup_minter/vending_minter/mock_params.rs
+++ b/test-suite/src/common_setup/setup_minter/vending_minter/mock_params.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{coin, Timestamp};
+use cosmwasm_std::{coin, Addr, Timestamp};
 use sg2::msg::CollectionParams;
 use sg_std::{GENESIS_MINT_START_TIME, NATIVE_DENOM};
 use vending_factory::{
@@ -30,10 +30,12 @@ pub fn mock_create_minter(
     splits_addr: Option<String>,
     collection_params: CollectionParams,
     start_time: Option<Timestamp>,
+    allowed_burn_collections: Option<Vec<Addr>>,
 ) -> VendingMinterCreateMsg {
     VendingMinterCreateMsg {
         init_msg: mock_init_extension(splits_addr, start_time),
         collection_params,
+        allowed_burn_collections,
     }
 }
 
@@ -44,6 +46,7 @@ pub fn mock_create_minter_init_msg(
     VendingMinterCreateMsg {
         init_msg,
         collection_params,
+        allowed_burn_collections: None,
     }
 }
 
@@ -53,10 +56,10 @@ pub fn mock_params(mint_denom: Option<String>) -> VendingMinterParams {
         allowed_sg721_code_ids: vec![1, 3, 5, 6],
         frozen: false,
         creation_fee: coin(CREATION_FEE, NATIVE_DENOM),
-        min_mint_price: coin(
+        min_mint_price: sg2::Fungible(coin(
             MIN_MINT_PRICE,
             mint_denom.unwrap_or_else(|| NATIVE_DENOM.to_string()),
-        ),
+        )),
         mint_fee_bps: MINT_FEE_FAIR_BURN,
         max_trading_offset_secs: 60 * 60 * 24 * 7,
         extension: ParamsExtension {

--- a/test-suite/src/common_setup/setup_minter/vending_minter/setup.rs
+++ b/test-suite/src/common_setup/setup_minter/vending_minter/setup.rs
@@ -5,20 +5,20 @@ use crate::common_setup::contract_boxes::{
 use crate::common_setup::msg::MinterCollectionResponse;
 use crate::common_setup::msg::MinterSetupParams;
 use crate::common_setup::setup_minter::common::parse_response::build_collection_response;
-use cosmwasm_std::{coin, coins, Addr};
-use cw_multi_test::Executor;
+use cosmwasm_std::{coin, coins, to_binary, Addr};
+use cw_multi_test::{AppResponse, Executor};
 use sg2::msg::CreateMinterMsg;
 use sg2::msg::{CollectionParams, Sg2ExecuteMsg};
 use sg_multi_test::StargazeApp;
 use sg_std::NATIVE_DENOM;
-use vending_factory::msg::VendingMinterInitMsgExtension;
+use vending_factory::msg::{VendingMinterInitMsgExtension, VendingUpdateParamsExtension};
 
 use crate::common_setup::msg::{CodeIds, MinterInstantiateParams};
+use crate::common_setup::setup_minter::common::constants::{CREATION_FEE, MINT_PRICE};
 use crate::common_setup::setup_minter::vending_minter::mock_params::{
     mock_create_minter, mock_params,
 };
-
-use crate::common_setup::setup_minter::common::constants::{CREATION_FEE, MINT_PRICE};
+use anyhow::Error;
 
 pub fn build_init_msg(
     init_msg: Option<VendingMinterInitMsgExtension>,
@@ -47,6 +47,7 @@ pub fn setup_minter_contract(setup_params: MinterSetupParams) -> MinterCollectio
     let collection_params = setup_params.collection_params;
     let start_time = setup_params.start_time;
     let init_msg = setup_params.init_msg;
+    let allowed_burn_collections = setup_params.allowed_burn_collections;
 
     let mint_denom: Option<String> = init_msg
         .as_ref()
@@ -65,14 +66,19 @@ pub fn setup_minter_contract(setup_params: MinterSetupParams) -> MinterCollectio
             None,
         )
         .unwrap();
-    let mut msg = mock_create_minter(splits_addr, collection_params, start_time);
+    let mut msg = mock_create_minter(
+        splits_addr,
+        collection_params,
+        start_time,
+        allowed_burn_collections,
+    );
     msg.init_msg = build_init_msg(init_msg, msg.clone(), num_tokens);
     msg.collection_params.code_id = sg721_code_id;
     msg.collection_params.info.creator = minter_admin.to_string();
     let creation_fee = coins(CREATION_FEE, NATIVE_DENOM);
     let msg = Sg2ExecuteMsg::CreateMinter(msg);
-
     let res = router.execute_contract(minter_admin, factory_addr.clone(), &msg, &creation_fee);
+
     build_collection_response(res, factory_addr)
 }
 
@@ -128,9 +134,53 @@ pub fn configure_minter(
             sg721_code_id: code_ids.sg721_code_id,
             start_time: minter_instantiate_params_vec[index].start_time,
             init_msg: minter_instantiate_params_vec[index].init_msg.clone(),
+            allowed_burn_collections: minter_instantiate_params_vec[index]
+                .allowed_burn_collections
+                .clone(),
         };
         let minter_collection_res = setup_minter_contract(setup_params);
         minter_collection_info.push(minter_collection_res);
     }
     minter_collection_info
+}
+
+pub fn sudo_update_params(
+    app: &mut StargazeApp,
+    collection_responses: &Vec<MinterCollectionResponse>,
+    code_ids: CodeIds,
+    update_msg: Option<sg2::msg::UpdateMinterParamsMsg<VendingUpdateParamsExtension>>,
+) -> Vec<Result<AppResponse, anyhow::Error>> {
+    let mut sudo_responses: Vec<Result<AppResponse, Error>> = vec![];
+    for collection_response in collection_responses {
+        let collection = collection_response.collection.clone().unwrap().to_string();
+
+        let update_msg = match update_msg.clone() {
+            Some(some_update_message) => some_update_message,
+            None => sg2::msg::UpdateMinterParamsMsg {
+                code_id: Some(code_ids.sg721_code_id),
+                add_sg721_code_ids: None,
+                rm_sg721_code_ids: None,
+                frozen: None,
+                creation_fee: Some(coin(0, NATIVE_DENOM)),
+                min_mint_price: Some(sg2::NonFungible(collection)),
+                mint_fee_bps: None,
+                max_trading_offset_secs: Some(100),
+                extension: VendingUpdateParamsExtension {
+                    max_token_limit: None,
+                    max_per_address_limit: None,
+                    airdrop_mint_price: None,
+                    airdrop_mint_fee_bps: None,
+                    shuffle_fee: None,
+                },
+            },
+        };
+        let sudo_update_msg = vending_factory::msg::SudoMsg::UpdateParams(Box::new(update_msg));
+
+        let sudo_res = app.sudo(cw_multi_test::SudoMsg::Wasm(cw_multi_test::WasmSudo {
+            contract_addr: collection_response.factory.clone().unwrap(),
+            msg: to_binary(&sudo_update_msg).unwrap(),
+        }));
+        sudo_responses.push(sudo_res);
+    }
+    sudo_responses
 }

--- a/test-suite/src/common_setup/templates.rs
+++ b/test-suite/src/common_setup/templates.rs
@@ -1,4 +1,4 @@
-use crate::common_setup::contract_boxes::{contract_sg721_base, custom_mock_app};
+use crate::common_setup::contract_boxes::custom_mock_app;
 use crate::common_setup::msg::MinterTemplateResponse;
 use crate::common_setup::{
     msg::MinterCollectionResponse,
@@ -7,29 +7,27 @@ use crate::common_setup::{
     setup_minter::vending_minter::setup::{configure_minter, vending_minter_code_ids},
 };
 
-use crate::common_setup::setup_minter::base_minter::setup::base_minter_sg721_nt_code_ids;
-use crate::common_setup::setup_minter::base_minter::setup::configure_base_minter;
-use crate::common_setup::setup_minter::common::constants::{
-    CREATION_FEE, MIN_MINT_PRICE_OPEN_EDITION,
-};
-use crate::common_setup::setup_minter::common::parse_response::build_collection_response;
-use crate::common_setup::setup_minter::open_edition_minter::mock_params::{
-    mock_create_minter, mock_params_custom,
-};
-use crate::common_setup::setup_minter::open_edition_minter::setup::open_edition_minter_code_ids;
-use cosmwasm_std::{coin, coins, Coin, Timestamp, Uint128};
-use cw_multi_test::{AppResponse, Contract, Executor};
-use open_edition_factory::types::{NftData, NftMetadataType};
-use sg2::msg::Sg2ExecuteMsg;
-use sg2::tests::mock_collection_params_1;
-use sg_multi_test::StargazeApp;
-use sg_std::{StargazeMsgWrapper, GENESIS_MINT_START_TIME, NATIVE_DENOM};
-
-use super::msg::Accounts;
+use super::msg::{Accounts, CodeIds, MinterTemplateResponseCodeIds};
 use super::setup_minter::base_minter::setup::base_minter_sg721_collection_code_ids;
 use super::setup_minter::common::constants::{MINT_PRICE, MIN_MINT_PRICE};
-use super::setup_minter::common::minter_params::minter_params_all;
-use super::setup_minter::vending_minter::setup::vending_minter_updatable_code_ids;
+use super::setup_minter::common::minter_params::{
+    minter_params_all, minter_params_allowed_burn_collections,
+};
+use super::setup_minter::open_edition_minter::setup::configure_open_edition_minter;
+use crate::common_setup::setup_accounts_and_block::CREATION_FEE;
+use crate::common_setup::setup_minter::base_minter::setup::base_minter_sg721_nt_code_ids;
+use crate::common_setup::setup_minter::base_minter::setup::configure_base_minter;
+use crate::common_setup::setup_minter::open_edition_minter::minter_params::minter_params_open_edition;
+use crate::common_setup::setup_minter::open_edition_minter::setup::open_edition_minter_code_ids;
+use crate::common_setup::setup_minter::vending_minter::setup::vending_minter_updatable_code_ids;
+use cosmwasm_std::{coin, Addr, Timestamp};
+use cw_multi_test::{AppResponse, BankSudo, SudoMsg};
+use open_edition_factory::msg::OpenEditionMinterInitMsgExtension;
+use open_edition_factory::state::{OpenEditionMinterParams, ParamsExtension};
+use open_edition_factory::types::NftData;
+use sg2::tests::{mock_collection_params_1, mock_collection_two};
+use sg_multi_test::StargazeApp;
+use sg_std::{GENESIS_MINT_START_TIME, NATIVE_DENOM};
 
 pub fn vending_minter_template(num_tokens: u32) -> MinterTemplateResponse<Accounts> {
     let mut app = custom_mock_app();
@@ -70,7 +68,7 @@ pub fn vending_minter_per_address_limit(
         whitelist: Some("invalid address".to_string()),
     };
 
-    let minter_params = minter_params_all(num_tokens, None, None, Some(init_msg));
+    let minter_params = minter_params_all(num_tokens, None, None, Some(init_msg), None);
     let code_ids = vending_minter_code_ids(&mut app);
     let minter_collection_response: Vec<MinterCollectionResponse> = configure_minter(
         &mut app,
@@ -105,7 +103,7 @@ pub fn vending_minter_with_ibc_asset(
         whitelist: None,
     };
 
-    let minter_params = minter_params_all(num_tokens, None, None, Some(init_msg));
+    let minter_params = minter_params_all(num_tokens, None, None, Some(init_msg), None);
     let code_ids = vending_minter_code_ids(&mut app);
     let minter_collection_response: Vec<MinterCollectionResponse> = configure_minter(
         &mut app,
@@ -280,6 +278,78 @@ pub fn base_minter_with_sg721nt(num_tokens: u32) -> MinterTemplateResponse<Accou
     }
 }
 
+pub fn base_minter_with_two_sg721_collections_burn_mint(
+    num_tokens: u32,
+    allowed_contracts: Vec<Addr>,
+) -> MinterTemplateResponse<Accounts> {
+    let mut router = custom_mock_app();
+    let (creator, buyer) = setup_accounts(&mut router);
+
+    router
+        .sudo(SudoMsg::Bank({
+            BankSudo::Mint {
+                to_address: creator.to_string(),
+                amount: vec![coin(CREATION_FEE * 2, NATIVE_DENOM)],
+            }
+        }))
+        .map_err(|err| println!("{:?}", err))
+        .ok();
+    let start_time = Timestamp::from_nanos(GENESIS_MINT_START_TIME);
+    let collection_params = mock_collection_params_1(Some(start_time));
+    let collection_params_2 = mock_collection_two(Some(start_time));
+    let minter_params = minter_params_token(num_tokens);
+    let minter_params_2 = minter_params_allowed_burn_collections(num_tokens, allowed_contracts);
+    let code_ids = base_minter_sg721_collection_code_ids(&mut router);
+    let minter_collection_response = configure_base_minter(
+        &mut router,
+        creator.clone(),
+        vec![collection_params, collection_params_2],
+        vec![minter_params, minter_params_2],
+        code_ids,
+    );
+    MinterTemplateResponse {
+        router,
+        collection_response_vec: minter_collection_response,
+        accts: Accounts { creator, buyer },
+    }
+}
+
+pub fn vending_minter_with_two_sg721_collections_burn_mint(
+    num_tokens: u32,
+    allowed_contracts: Vec<Addr>,
+) -> MinterTemplateResponse<Accounts> {
+    let mut router = custom_mock_app();
+    let (creator, buyer) = setup_accounts(&mut router);
+
+    router
+        .sudo(SudoMsg::Bank({
+            BankSudo::Mint {
+                to_address: creator.to_string(),
+                amount: vec![coin(CREATION_FEE * 2, NATIVE_DENOM)],
+            }
+        }))
+        .map_err(|err| println!("{:?}", err))
+        .ok();
+    let start_time = Timestamp::from_nanos(GENESIS_MINT_START_TIME);
+    let collection_params = mock_collection_params_1(Some(start_time));
+    let collection_params_2 = mock_collection_two(Some(start_time));
+    let minter_params = minter_params_token(num_tokens);
+    let minter_params_2 = minter_params_allowed_burn_collections(num_tokens, allowed_contracts);
+    let code_ids = vending_minter_code_ids(&mut router);
+    let minter_collection_response = configure_minter(
+        &mut router,
+        creator.clone(),
+        vec![collection_params, collection_params_2],
+        vec![minter_params, minter_params_2],
+        code_ids,
+    );
+    MinterTemplateResponse {
+        router,
+        collection_response_vec: minter_collection_response,
+        accts: Accounts { creator, buyer },
+    }
+}
+
 pub fn base_minter_with_sg721(num_tokens: u32) -> MinterTemplateResponse<Accounts> {
     let mut router = custom_mock_app();
     let (creator, buyer) = setup_accounts(&mut router);
@@ -326,91 +396,294 @@ pub fn base_minter_with_specified_sg721(
     }
 }
 
-#[derive(Default)]
-pub struct OpenEditionMinterCustomParams<'a> {
-    pub denom: Option<&'a str>,
-    pub mint_fee_bps: Option<u64>,
-    pub airdrop_mint_price_amount: Option<Uint128>,
+pub fn open_edition_minter_custom_template(
+    params_extension: ParamsExtension,
+    init_msg: OpenEditionMinterInitMsgExtension,
+) -> Result<MinterTemplateResponseCodeIds<Accounts>, anyhow::Result<AppResponse>> {
+    let mut app = custom_mock_app();
+    let (creator, buyer) = setup_accounts(&mut app);
+    let code_ids = open_edition_minter_code_ids(&mut app);
+    let collection_params = mock_collection_params_1(None);
+    let minter_params =
+        minter_params_open_edition(params_extension, init_msg, None, None, None, None, None);
+
+    let minter_collection_response = configure_open_edition_minter(
+        &mut app,
+        creator.clone(),
+        vec![collection_params],
+        vec![minter_params],
+        code_ids.clone(),
+    );
+    println!(
+        "minter collection response is {:?}",
+        minter_collection_response[0].error
+    );
+    Ok(MinterTemplateResponseCodeIds {
+        router: app,
+        collection_response_vec: minter_collection_response,
+        accts: Accounts { creator, buyer },
+        code_ids,
+    })
 }
 
-// Custom params set to a high level function to ease the tests
-#[allow(clippy::too_many_arguments)]
-pub fn open_edition_minter_custom_template(
-    start_minter_time: Option<Timestamp>,
-    end_minter_time: Option<Timestamp>,
-    nft_data: Option<NftData>,
-    max_per_address_limit: Option<u32>,
-    per_address_limit_minter: Option<u32>,
-    mint_price_minter: Option<Coin>,
-    custom_params: OpenEditionMinterCustomParams,
-    sg721_code: Option<Box<dyn Contract<StargazeMsgWrapper>>>,
-    sg721_codeid: Option<u64>,
+pub fn open_edition_minter_nft_data(
+    params_extension: ParamsExtension,
+    init_msg: OpenEditionMinterInitMsgExtension,
+    nft_data: NftData,
 ) -> Result<MinterTemplateResponse<Accounts>, anyhow::Result<AppResponse>> {
     let mut app = custom_mock_app();
     let (creator, buyer) = setup_accounts(&mut app);
-    let code_ids =
-        open_edition_minter_code_ids(&mut app, sg721_code.unwrap_or_else(contract_sg721_base));
+    let code_ids = open_edition_minter_code_ids(&mut app);
+    let collection_params = mock_collection_params_1(None);
+    let minter_params = minter_params_open_edition(
+        params_extension,
+        init_msg,
+        None,
+        None,
+        Some(nft_data),
+        None,
+        None,
+    );
 
-    // Factory params
-    let mut factory_params = mock_params_custom(custom_params);
-    factory_params.extension.max_per_address_limit =
-        max_per_address_limit.unwrap_or(factory_params.extension.max_per_address_limit);
-
-    let factory_addr = app.instantiate_contract(
-        code_ids.factory_code_id,
+    let minter_collection_response = configure_open_edition_minter(
+        &mut app,
         creator.clone(),
-        &open_edition_factory::msg::InstantiateMsg {
-            params: factory_params,
-        },
-        &[],
-        "factory",
-        None,
+        vec![collection_params],
+        vec![minter_params],
+        code_ids,
     );
-
-    let factory_addr = factory_addr.unwrap();
-
-    // Minter -> Default params
-    let start_time = Timestamp::from_nanos(GENESIS_MINT_START_TIME + 100);
-    let end_time = Timestamp::from_nanos(GENESIS_MINT_START_TIME + 10_000);
-    let per_address_limit_minter = per_address_limit_minter.or(Some(1));
-    let mint_price = mint_price_minter.or_else(|| {
-        Some(Coin {
-            denom: NATIVE_DENOM.to_string(),
-            amount: Uint128::new(MIN_MINT_PRICE_OPEN_EDITION),
-        })
-    });
-    let collection_params = mock_collection_params_1(Some(start_time));
-    let default_nft_data = nft_data.unwrap_or(NftData {
-        nft_data_type: NftMetadataType::OffChainMetadata,
-        extension: None,
-        token_uri: Some(
-            "ipfs://bafybeiavall5udkxkdtdm4djezoxrmfc6o5fn2ug3ymrlvibvwmwydgrkm/1.jpg".to_string(),
-        ),
-    });
-    let mut msg = mock_create_minter(
-        start_minter_time.or(Some(start_time)),
-        end_minter_time.or(Some(end_time)),
-        mint_price,
-        per_address_limit_minter,
-        default_nft_data,
-        collection_params,
-        None,
-    );
-    msg.collection_params.code_id = sg721_codeid.unwrap_or(3);
-    msg.collection_params.info.creator = creator.to_string();
-    let creation_fee = coins(CREATION_FEE, NATIVE_DENOM);
-    let msg = Sg2ExecuteMsg::CreateMinter(msg);
-
-    let res = app.execute_contract(creator.clone(), factory_addr.clone(), &msg, &creation_fee);
-    if res.is_err() {
-        return Err(res);
-    }
-
-    let minter_collection_res = build_collection_response(res, factory_addr);
-
     Ok(MinterTemplateResponse {
         router: app,
-        collection_response_vec: vec![minter_collection_res],
+        collection_response_vec: minter_collection_response,
         accts: Accounts { creator, buyer },
     })
 }
+
+pub fn open_edition_minter_start_and_end_time(
+    params_extension: ParamsExtension,
+    init_msg: OpenEditionMinterInitMsgExtension,
+    start_time: Option<Timestamp>,
+    end_time: Option<Timestamp>,
+) -> Result<MinterTemplateResponse<Accounts>, anyhow::Result<AppResponse>> {
+    let mut app = custom_mock_app();
+    let (creator, buyer) = setup_accounts(&mut app);
+    let code_ids = open_edition_minter_code_ids(&mut app);
+    let collection_params = mock_collection_params_1(None);
+    let minter_params = minter_params_open_edition(
+        params_extension,
+        init_msg,
+        start_time,
+        end_time,
+        None,
+        None,
+        None,
+    );
+
+    let minter_collection_response = configure_open_edition_minter(
+        &mut app,
+        creator.clone(),
+        vec![collection_params],
+        vec![minter_params],
+        code_ids,
+    );
+    Ok(MinterTemplateResponse {
+        router: app,
+        collection_response_vec: minter_collection_response,
+        accts: Accounts { creator, buyer },
+    })
+}
+
+pub fn open_edition_minter_custom_code_ids(
+    app: StargazeApp,
+    params_extension: ParamsExtension,
+    init_msg: OpenEditionMinterInitMsgExtension,
+    code_ids: CodeIds,
+) -> Result<MinterTemplateResponse<Accounts>, anyhow::Result<AppResponse>> {
+    let mut app = app;
+    let (creator, buyer) = setup_accounts(&mut app);
+    let collection_params = mock_collection_params_1(None);
+    let minter_params =
+        minter_params_open_edition(params_extension, init_msg, None, None, None, None, None);
+
+    let minter_collection_response = configure_open_edition_minter(
+        &mut app,
+        creator.clone(),
+        vec![collection_params],
+        vec![minter_params],
+        code_ids,
+    );
+    Ok(MinterTemplateResponse {
+        router: app,
+        collection_response_vec: minter_collection_response,
+        accts: Accounts { creator, buyer },
+    })
+}
+
+pub fn base_minter_with_sudo_update_params_template(
+    num_tokens: u32,
+) -> MinterTemplateResponseCodeIds<Accounts> {
+    let mut app = custom_mock_app();
+    let (creator, buyer) = setup_accounts(&mut app);
+    let start_time = Timestamp::from_nanos(GENESIS_MINT_START_TIME);
+    let collection_params = mock_collection_params_1(Some(start_time));
+    let minter_params = minter_params_token(num_tokens);
+    let code_ids = base_minter_sg721_collection_code_ids(&mut app);
+    let minter_collection_response: Vec<MinterCollectionResponse> = configure_minter(
+        &mut app,
+        creator.clone(),
+        vec![collection_params],
+        vec![minter_params],
+        code_ids.clone(),
+    );
+    MinterTemplateResponseCodeIds {
+        router: app,
+        collection_response_vec: minter_collection_response,
+        accts: Accounts { creator, buyer },
+        code_ids,
+    }
+}
+
+pub fn vending_minter_template_with_code_ids_template(
+    num_tokens: u32,
+) -> MinterTemplateResponseCodeIds<Accounts> {
+    let mut app = custom_mock_app();
+    let (creator, buyer) = setup_accounts(&mut app);
+    let start_time = Timestamp::from_nanos(GENESIS_MINT_START_TIME);
+    let collection_params = mock_collection_params_1(Some(start_time));
+    let minter_params = minter_params_token(num_tokens);
+    let code_ids = vending_minter_code_ids(&mut app);
+    let minter_collection_response: Vec<MinterCollectionResponse> = configure_minter(
+        &mut app,
+        creator.clone(),
+        vec![collection_params],
+        vec![minter_params],
+        code_ids.clone(),
+    );
+    MinterTemplateResponseCodeIds {
+        router: app,
+        collection_response_vec: minter_collection_response,
+        accts: Accounts { creator, buyer },
+        code_ids,
+    }
+}
+
+pub fn open_edition_minter_with_two_sg721_collections_burn_mint(
+    params_extension: ParamsExtension,
+    init_msg: OpenEditionMinterInitMsgExtension,
+    allowed_contracts: Vec<Addr>,
+) -> Result<MinterTemplateResponse<Accounts>, anyhow::Result<AppResponse>> {
+    let mut router = custom_mock_app();
+    let (creator, buyer) = setup_accounts(&mut router);
+    router
+        .sudo(SudoMsg::Bank({
+            BankSudo::Mint {
+                to_address: creator.to_string(),
+                amount: vec![coin(CREATION_FEE * 2, NATIVE_DENOM)],
+            }
+        }))
+        .map_err(|err| println!("{:?}", err))
+        .ok();
+    let start_time = Timestamp::from_nanos(GENESIS_MINT_START_TIME);
+    let collection_params = mock_collection_params_1(Some(start_time));
+    let collection_params_2 = mock_collection_two(Some(start_time));
+    let minter_params = minter_params_open_edition(
+        params_extension.clone(),
+        init_msg.clone(),
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+    let minter_params_2 = minter_params_open_edition(
+        params_extension,
+        init_msg,
+        None,
+        None,
+        None,
+        Some(allowed_contracts),
+        None,
+    );
+    let code_ids = open_edition_minter_code_ids(&mut router);
+    let minter_collection_response = configure_open_edition_minter(
+        &mut router,
+        creator.clone(),
+        vec![collection_params, collection_params_2],
+        vec![minter_params, minter_params_2],
+        code_ids,
+    );
+    Ok(MinterTemplateResponse {
+        router,
+        collection_response_vec: minter_collection_response,
+        accts: Accounts { creator, buyer },
+    })
+}
+
+pub fn open_edition_minter_ibc_template(
+    params_extension: ParamsExtension,
+    init_msg: OpenEditionMinterInitMsgExtension,
+    custom_minter_params: OpenEditionMinterParams,
+) -> Result<MinterTemplateResponseCodeIds<Accounts>, anyhow::Result<AppResponse>> {
+    let mut app = custom_mock_app();
+    let (creator, buyer) = setup_accounts(&mut app);
+    let code_ids = open_edition_minter_code_ids(&mut app);
+    let collection_params = mock_collection_params_1(None);
+    let minter_params = minter_params_open_edition(
+        params_extension,
+        init_msg,
+        None,
+        None,
+        None,
+        None,
+        Some(custom_minter_params),
+    );
+
+    let minter_collection_response = configure_open_edition_minter(
+        &mut app,
+        creator.clone(),
+        vec![collection_params],
+        vec![minter_params],
+        code_ids.clone(),
+    );
+    Ok(MinterTemplateResponseCodeIds {
+        router: app,
+        collection_response_vec: minter_collection_response,
+        accts: Accounts { creator, buyer },
+        code_ids,
+    })
+}
+
+// pub fn open_edition_minter_ibc_template_custom_code_ids(
+//     params_extension: ParamsExtension,
+//     init_msg: OpenEditionMinterInitMsgExtension,
+//     custom_minter_params: OpenEditionMinterParams,
+//     code_ids: CodeIds,
+// ) -> Result<MinterTemplateResponseCodeIds<Accounts>, anyhow::Result<AppResponse>> {
+//     let mut app = custom_mock_app();
+//     let (creator, buyer) = setup_accounts(&mut app);
+//     let collection_params = mock_collection_params_1(None);
+//     let code_ids = open_edition_minter_code_ids(&mut app);
+//     let minter_params = minter_params_open_edition(
+//         params_extension,
+//         init_msg,
+//         None,
+//         None,
+//         None,
+//         None,
+//         Some(custom_minter_params),
+//     );
+
+//     let minter_collection_response = configure_open_edition_minter(
+//         &mut app,
+//         creator.clone(),
+//         vec![collection_params],
+//         vec![minter_params],
+//         code_ids.clone(),
+//     );
+//     Ok(MinterTemplateResponseCodeIds {
+//         router: app,
+//         collection_response_vec: minter_collection_response,
+//         accts: Accounts { creator, buyer },
+//         code_ids,
+//     })
+// }

--- a/test-suite/src/open_edition_factory/tests.rs
+++ b/test-suite/src/open_edition_factory/tests.rs
@@ -1,3 +1,4 @@
 mod common;
 mod integration_tests;
 mod queries;
+mod sudo_tests;

--- a/test-suite/src/open_edition_factory/tests/common.rs
+++ b/test-suite/src/open_edition_factory/tests/common.rs
@@ -1,6 +1,5 @@
 use crate::common_setup::contract_boxes::{contract_open_edition_factory, custom_mock_app};
-use crate::common_setup::setup_minter::open_edition_minter::mock_params::mock_params_custom;
-use crate::common_setup::templates::OpenEditionMinterCustomParams;
+use crate::common_setup::setup_minter::open_edition_minter::mock_params::mock_params_proper;
 use cosmwasm_std::Addr;
 use cw_multi_test::Executor;
 use open_edition_factory::helpers::FactoryContract;
@@ -14,7 +13,7 @@ pub fn proper_instantiate() -> (StargazeApp, FactoryContract) {
     let factory_id = app.store_code(contract_open_edition_factory());
     let minter_id = 2;
 
-    let mut params = mock_params_custom(OpenEditionMinterCustomParams::default());
+    let mut params = mock_params_proper();
     params.code_id = minter_id;
 
     let factory_contract_addr = app

--- a/test-suite/src/open_edition_factory/tests/queries.rs
+++ b/test-suite/src/open_edition_factory/tests/queries.rs
@@ -9,8 +9,7 @@ mod tests {
     use sg_multi_test::StargazeApp;
 
     use crate::common_setup::contract_boxes::{contract_open_edition_factory, custom_mock_app};
-    use crate::common_setup::setup_minter::open_edition_minter::mock_params::mock_params_custom;
-    use crate::common_setup::templates::OpenEditionMinterCustomParams;
+    use crate::common_setup::setup_minter::open_edition_minter::mock_params::mock_params_proper;
 
     const GOVERNANCE: &str = "governance";
 
@@ -19,7 +18,7 @@ mod tests {
         let factory_id = app.store_code(contract_open_edition_factory());
         let minter_id = 2;
 
-        let mut params = mock_params_custom(OpenEditionMinterCustomParams::default());
+        let mut params = mock_params_proper();
         params.code_id = minter_id;
 
         let factory_contract_addr = app

--- a/test-suite/src/open_edition_factory/tests/sudo_tests.rs
+++ b/test-suite/src/open_edition_factory/tests/sudo_tests.rs
@@ -1,0 +1,128 @@
+use crate::common_setup::msg::MinterCollectionResponse;
+use crate::common_setup::setup_minter::common::constants::DEV_ADDRESS;
+use crate::common_setup::setup_minter::open_edition_minter::minter_params::{
+    default_nft_data, init_msg,
+};
+use crate::common_setup::setup_minter::open_edition_minter::setup::sudo_update_params;
+use crate::common_setup::templates::open_edition_minter_custom_template;
+use base_factory::msg::ParamsResponse;
+use cosmwasm_std::{coin, Addr, Coin, Uint128};
+use open_edition_factory::msg::OpenEditionUpdateParamsExtension;
+use open_edition_factory::state::ParamsExtension;
+use sg2::query::Sg2QueryMsg::Params;
+use sg_std::NATIVE_DENOM;
+
+#[test]
+fn happy_path_with_params_update() {
+    let params_extension = ParamsExtension {
+        max_per_address_limit: 10,
+        airdrop_mint_fee_bps: 100,
+        airdrop_mint_price: Coin {
+            denom: NATIVE_DENOM.to_string(),
+            amount: Uint128::new(100_000_000u128),
+        },
+        dev_fee_address: DEV_ADDRESS.to_string(),
+    };
+    let per_address_limit_minter = Some(2);
+    let init_msg = init_msg(
+        default_nft_data(),
+        per_address_limit_minter,
+        None,
+        None,
+        None,
+    );
+    let vt = open_edition_minter_custom_template(params_extension, init_msg).unwrap();
+    let mut router = vt.router;
+    sudo_update_params(&mut router, &vt.collection_response_vec, vt.code_ids, None);
+}
+
+#[test]
+fn sudo_params_update_invalid_nft_collection() {
+    let params_extension = ParamsExtension {
+        max_per_address_limit: 10,
+        airdrop_mint_fee_bps: 100,
+        airdrop_mint_price: Coin {
+            denom: NATIVE_DENOM.to_string(),
+            amount: Uint128::new(100_000_000u128),
+        },
+        dev_fee_address: DEV_ADDRESS.to_string(),
+    };
+    let per_address_limit_minter = Some(2);
+    let init_msg = init_msg(
+        default_nft_data(),
+        per_address_limit_minter,
+        None,
+        None,
+        None,
+    );
+    let vt = open_edition_minter_custom_template(params_extension, init_msg).unwrap();
+    let mut router = vt.router;
+    let mut response_collection_vec: Vec<MinterCollectionResponse> = vec![];
+    for entry in vt.collection_response_vec {
+        let new_entry = MinterCollectionResponse {
+            minter: entry.minter,
+            collection: Some(Addr::unchecked("fake_address")),
+            factory: entry.factory,
+            error: entry.error,
+        };
+        response_collection_vec.push(new_entry);
+    }
+    let sudo_responses =
+        sudo_update_params(&mut router, &response_collection_vec, vt.code_ids, None);
+    let sudo_response_1 = sudo_responses.first();
+    let err = sudo_response_1.unwrap().as_ref().unwrap_err().to_string();
+    assert_eq!(err, "InvalidCollectionAddress".to_string());
+}
+
+#[test]
+fn sudo_params_update_creation_fee() {
+    let params_extension = ParamsExtension {
+        max_per_address_limit: 10,
+        airdrop_mint_fee_bps: 100,
+        airdrop_mint_price: Coin {
+            denom: NATIVE_DENOM.to_string(),
+            amount: Uint128::new(100_000_000u128),
+        },
+        dev_fee_address: DEV_ADDRESS.to_string(),
+    };
+    let per_address_limit_minter = Some(2);
+    let init_msg = init_msg(
+        default_nft_data(),
+        per_address_limit_minter,
+        None,
+        None,
+        None,
+    );
+    let vt = open_edition_minter_custom_template(params_extension, init_msg).unwrap();
+    let collection = vt.collection_response_vec[0].collection.clone().unwrap();
+    let factory = vt.collection_response_vec[0].factory.clone().unwrap();
+    let code_ids = vt.code_ids.clone();
+    let mut router = vt.router;
+
+    let update_msg = sg2::msg::UpdateMinterParamsMsg {
+        code_id: Some(code_ids.sg721_code_id),
+        add_sg721_code_ids: None,
+        rm_sg721_code_ids: None,
+        frozen: None,
+        creation_fee: Some(coin(999, NATIVE_DENOM)),
+        min_mint_price: Some(sg2::NonFungible(collection.to_string())),
+        mint_fee_bps: None,
+        max_trading_offset_secs: Some(100),
+        extension: OpenEditionUpdateParamsExtension {
+            min_mint_price: Some(coin(10, NATIVE_DENOM)),
+            max_per_address_limit: None,
+            airdrop_mint_price: None,
+            airdrop_mint_fee_bps: None,
+            dev_fee_address: Some(DEV_ADDRESS.to_string()),
+        },
+    };
+    sudo_update_params(
+        &mut router,
+        &vt.collection_response_vec,
+        vt.code_ids,
+        Some(update_msg),
+    );
+
+    let res: ParamsResponse = router.wrap().query_wasm_smart(factory, &Params {}).unwrap();
+    assert_eq!(res.params.creation_fee, coin(999, NATIVE_DENOM));
+}

--- a/test-suite/src/open_edition_minter/tests.rs
+++ b/test-suite/src/open_edition_minter/tests.rs
@@ -1,5 +1,6 @@
 mod address_limit;
 mod allowed_code_ids;
+mod burn_to_mint;
 mod complete_mint_all_outcomes_validation;
 mod factory_create_minter;
 mod frozen_factory;

--- a/test-suite/src/open_edition_minter/tests/address_limit.rs
+++ b/test-suite/src/open_edition_minter/tests/address_limit.rs
@@ -1,31 +1,41 @@
-use cosmwasm_std::coins;
+use cosmwasm_std::{coins, Coin, Uint128};
 use cw_multi_test::Executor;
+use open_edition_factory::state::ParamsExtension;
 use sg_std::{GENESIS_MINT_START_TIME, NATIVE_DENOM};
 
 use open_edition_minter::msg::ConfigResponse;
 use open_edition_minter::msg::{ExecuteMsg, QueryMsg};
 
 use crate::common_setup::setup_accounts_and_block::setup_block_time;
-use crate::common_setup::templates::{
-    open_edition_minter_custom_template, OpenEditionMinterCustomParams,
+use crate::common_setup::setup_minter::common::constants::DEV_ADDRESS;
+use crate::common_setup::setup_minter::open_edition_minter::minter_params::{
+    default_nft_data, init_msg,
 };
+use crate::common_setup::templates::open_edition_minter_custom_template;
 
 const MINT_PRICE: u128 = 100_000_000;
 
 #[test]
 fn check_per_address_limit() {
-    let vt = open_edition_minter_custom_template(
+    let params_extension = ParamsExtension {
+        max_per_address_limit: 10,
+        airdrop_mint_fee_bps: 100,
+        airdrop_mint_price: Coin {
+            denom: NATIVE_DENOM.to_string(),
+            amount: Uint128::new(100_000_000u128),
+        },
+        dev_fee_address: DEV_ADDRESS.to_string(),
+    };
+    let per_address_limit_minter = Some(2);
+    let init_msg = init_msg(
+        default_nft_data(),
+        per_address_limit_minter,
         None,
         None,
         None,
-        Some(10),
-        Some(2),
-        None,
-        OpenEditionMinterCustomParams::default(),
-        None,
-        None,
-    )
-    .unwrap();
+    );
+    let vt = open_edition_minter_custom_template(params_extension, init_msg).unwrap();
+
     let (mut router, creator, buyer) = (vt.router, vt.accts.creator, vt.accts.buyer);
     let minter_addr = vt.collection_response_vec[0].minter.clone().unwrap();
     // Set to a valid mint time

--- a/test-suite/src/open_edition_minter/tests/allowed_code_ids.rs
+++ b/test-suite/src/open_edition_minter/tests/allowed_code_ids.rs
@@ -1,32 +1,50 @@
-use crate::common_setup::templates::{
-    open_edition_minter_custom_template, OpenEditionMinterCustomParams,
+use cosmwasm_std::{Coin, Uint128};
+use open_edition_factory::state::ParamsExtension;
+use sg_std::NATIVE_DENOM;
+
+use crate::common_setup::{
+    contract_boxes::custom_mock_app,
+    setup_minter::{
+        common::constants::DEV_ADDRESS,
+        open_edition_minter::{
+            minter_params::{default_nft_data, init_msg},
+            setup::open_edition_minter_code_ids,
+        },
+    },
+    templates::open_edition_minter_custom_code_ids,
 };
 
 #[test]
 fn invalid_code_id() {
-    // Set an invalid code id for the nft contract
-    let vt = open_edition_minter_custom_template(
+    let params_extension = ParamsExtension {
+        max_per_address_limit: 10,
+        airdrop_mint_fee_bps: 100,
+        airdrop_mint_price: Coin {
+            denom: NATIVE_DENOM.to_string(),
+            amount: Uint128::new(100_000_000u128),
+        },
+        dev_fee_address: DEV_ADDRESS.to_string(),
+    };
+    let per_address_limit_minter = Some(2);
+    let init_msg = init_msg(
+        default_nft_data(),
+        per_address_limit_minter,
         None,
         None,
         None,
-        Some(10),
-        Some(5),
-        None,
-        OpenEditionMinterCustomParams::default(),
-        None,
-        Some(19),
     );
+    let mut app = custom_mock_app();
+    let mut code_ids = open_edition_minter_code_ids(&mut app);
+    code_ids.sg721_code_id = 19;
+    let vt =
+        open_edition_minter_custom_code_ids(app, params_extension, init_msg, code_ids).unwrap();
     assert_eq!(
-        vt.err()
+        vt.collection_response_vec[0]
+            .error
+            .as_ref()
             .unwrap()
-            .err()
-            .unwrap()
-            .source()
-            .unwrap()
+            .root_cause()
             .to_string(),
         "InvalidCollectionCodeId 19".to_string()
     );
-
-    // All the other tests related to Sudo params of the factory contract are tested in the factory
-    // tests
 }

--- a/test-suite/src/open_edition_minter/tests/burn_to_mint.rs
+++ b/test-suite/src/open_edition_minter/tests/burn_to_mint.rs
@@ -1,0 +1,182 @@
+use cosmwasm_std::Addr;
+use cosmwasm_std::{coin, to_binary, Coin, Uint128};
+use cw721::{Cw721ExecuteMsg, Cw721QueryMsg};
+use cw_multi_test::Executor;
+use open_edition_factory::state::ParamsExtension;
+use open_edition_minter::msg::ExecuteMsg;
+use sg_std::GENESIS_MINT_START_TIME;
+use sg_std::NATIVE_DENOM;
+
+use crate::common_setup::setup_accounts_and_block::setup_block_time;
+use crate::common_setup::{
+    setup_minter::{
+        common::constants::DEV_ADDRESS,
+        open_edition_minter::minter_params::{default_nft_data, init_msg},
+    },
+    templates::open_edition_minter_with_two_sg721_collections_burn_mint,
+};
+
+#[test]
+fn check_burns_tokens_when_received() {
+    let params_extension = ParamsExtension {
+        max_per_address_limit: 10,
+        airdrop_mint_fee_bps: 100,
+        airdrop_mint_price: Coin {
+            denom: NATIVE_DENOM.to_string(),
+            amount: Uint128::new(100_000_000u128),
+        },
+        dev_fee_address: DEV_ADDRESS.to_string(),
+    };
+    let per_address_limit_minter = Some(2);
+    let init_msg = init_msg(
+        default_nft_data(),
+        per_address_limit_minter,
+        None,
+        None,
+        None,
+    );
+    let allowed_collections = vec![Addr::unchecked("contract2")];
+    let vt = open_edition_minter_with_two_sg721_collections_burn_mint(
+        params_extension,
+        init_msg,
+        allowed_collections,
+    )
+    .unwrap();
+    let (mut router, creator) = (vt.router, vt.accts.creator);
+    let minter_addr_1 = vt.collection_response_vec[0].minter.clone().unwrap();
+    let collection_addr_1 = vt.collection_response_vec[0].collection.clone().unwrap();
+
+    let minter_addr_2 = vt.collection_response_vec[1].minter.clone().unwrap();
+
+    setup_block_time(&mut router, GENESIS_MINT_START_TIME + 101, None);
+
+    let mint_price = 100_000_000;
+    // Mint one NFT
+    let mint_msg = ExecuteMsg::Mint {};
+    let res = router.execute_contract(
+        creator.clone(),
+        minter_addr_1,
+        &mint_msg,
+        &[coin(mint_price, NATIVE_DENOM)],
+    );
+    assert!(res.is_ok());
+
+    let num_tokens_res: cw721::NumTokensResponse = router
+        .wrap()
+        .query_wasm_smart(collection_addr_1.clone(), &Cw721QueryMsg::NumTokens {})
+        .unwrap();
+    // one token after mint
+    assert_eq!(num_tokens_res.count, 1);
+
+    let send_nft = Cw721ExecuteMsg::SendNft {
+        contract: minter_addr_2.to_string(),
+        token_id: 1.to_string(),
+        msg: to_binary("this is a test").unwrap(),
+    };
+
+    let res = router.execute_contract(creator, collection_addr_1.clone(), &send_nft, &[]);
+    assert!(res.is_ok());
+
+    let num_tokens_res: cw721::NumTokensResponse = router
+        .wrap()
+        .query_wasm_smart(collection_addr_1, &Cw721QueryMsg::NumTokens {})
+        .unwrap();
+
+    // zero tokens after burn
+    assert_eq!(num_tokens_res.count, 0);
+}
+
+#[test]
+fn check_mints_new_tokens_when_received() {
+    let params_extension = ParamsExtension {
+        max_per_address_limit: 10,
+        airdrop_mint_fee_bps: 100,
+        airdrop_mint_price: Coin {
+            denom: NATIVE_DENOM.to_string(),
+            amount: Uint128::new(100_000_000u128),
+        },
+        dev_fee_address: DEV_ADDRESS.to_string(),
+    };
+    let per_address_limit_minter = Some(2);
+    let init_msg = init_msg(
+        default_nft_data(),
+        per_address_limit_minter,
+        None,
+        None,
+        None,
+    );
+    let allowed_collections = vec![Addr::unchecked("contract2")];
+    let vt = open_edition_minter_with_two_sg721_collections_burn_mint(
+        params_extension,
+        init_msg,
+        allowed_collections,
+    )
+    .unwrap();
+    let (mut router, creator) = (vt.router, vt.accts.creator);
+    let minter_addr_1 = vt.collection_response_vec[0].minter.clone().unwrap();
+    let collection_addr_1 = vt.collection_response_vec[0].collection.clone().unwrap();
+
+    let minter_addr_2 = vt.collection_response_vec[1].minter.clone().unwrap();
+    let collection_addr_2 = vt.collection_response_vec[1].collection.clone().unwrap();
+
+    setup_block_time(&mut router, GENESIS_MINT_START_TIME + 101, None);
+    // Mint one NFT
+    let mint_price = 100_000_000;
+
+    let mint_msg = ExecuteMsg::Mint {};
+    let res = router.execute_contract(
+        creator.clone(),
+        minter_addr_1,
+        &mint_msg,
+        &[coin(mint_price, NATIVE_DENOM)],
+    );
+    assert!(res.is_ok());
+
+    let num_tokens_res: cw721::NumTokensResponse = router
+        .wrap()
+        .query_wasm_smart(collection_addr_1.clone(), &Cw721QueryMsg::NumTokens {})
+        .unwrap();
+    // one token after mint
+    assert_eq!(num_tokens_res.count, 1);
+
+    let res = router.execute_contract(
+        creator.clone(),
+        minter_addr_2.clone(),
+        &mint_msg,
+        &[coin(mint_price, NATIVE_DENOM)],
+    );
+    assert!(res.is_ok());
+
+    let num_tokens_res: cw721::NumTokensResponse = router
+        .wrap()
+        .query_wasm_smart(collection_addr_2.clone(), &Cw721QueryMsg::NumTokens {})
+        .unwrap();
+    // one token after mint
+    assert_eq!(num_tokens_res.count, 1);
+
+    let send_nft = Cw721ExecuteMsg::SendNft {
+        contract: minter_addr_2.to_string(),
+        token_id: 1.to_string(),
+        msg: to_binary("this is a test").unwrap(),
+    };
+    let res = router.execute_contract(
+        creator,
+        collection_addr_1.clone(),
+        &send_nft,
+        &[coin(mint_price, NATIVE_DENOM)],
+    );
+    assert!(res.is_ok());
+    let num_tokens_res: cw721::NumTokensResponse = router
+        .wrap()
+        .query_wasm_smart(collection_addr_1, &Cw721QueryMsg::NumTokens {})
+        .unwrap();
+    // one token after mint
+    assert_eq!(num_tokens_res.count, 0);
+
+    let num_tokens_res: cw721::NumTokensResponse = router
+        .wrap()
+        .query_wasm_smart(collection_addr_2, &Cw721QueryMsg::NumTokens {})
+        .unwrap();
+    // one token after mint
+    assert_eq!(num_tokens_res.count, 2);
+}

--- a/test-suite/src/open_edition_minter/tests/complete_mint_all_outcomes_validation.rs
+++ b/test-suite/src/open_edition_minter/tests/complete_mint_all_outcomes_validation.rs
@@ -1,6 +1,7 @@
 use cosmwasm_std::{coins, Coin, Timestamp, Uint128};
 use cw721::{Cw721QueryMsg, NumTokensResponse, OwnerOfResponse};
 use cw_multi_test::{BankSudo, Executor, SudoMsg};
+use open_edition_factory::state::ParamsExtension;
 use sg_std::{GENESIS_MINT_START_TIME, NATIVE_DENOM};
 
 use open_edition_minter::msg::{EndTimeResponse, ExecuteMsg, QueryMsg, TotalMintCountResponse};
@@ -9,26 +10,34 @@ use sg4::StatusResponse;
 
 use crate::common_setup::setup_accounts_and_block::{coins_for_msg, setup_block_time};
 use crate::common_setup::setup_minter::common::constants::DEV_ADDRESS;
-use crate::common_setup::templates::{
-    open_edition_minter_custom_template, OpenEditionMinterCustomParams,
+use crate::common_setup::setup_minter::open_edition_minter::minter_params::{
+    default_nft_data, init_msg,
 };
+use crate::common_setup::templates::open_edition_minter_custom_template;
 
 const MINT_PRICE: u128 = 100_000_000;
 
 #[test]
 fn check_mint_revenues_distribution() {
-    let vt = open_edition_minter_custom_template(
+    let params_extension = ParamsExtension {
+        max_per_address_limit: 10,
+        airdrop_mint_fee_bps: 100,
+        airdrop_mint_price: Coin {
+            denom: NATIVE_DENOM.to_string(),
+            amount: Uint128::new(100_000_000u128),
+        },
+        dev_fee_address: DEV_ADDRESS.to_string(),
+    };
+    let per_address_limit_minter = Some(3);
+    let init_msg = init_msg(
+        default_nft_data(),
+        per_address_limit_minter,
         None,
         None,
         None,
-        None,
-        Some(3),
-        None,
-        OpenEditionMinterCustomParams::default(),
-        None,
-        None,
-    )
-    .unwrap();
+    );
+    let vt = open_edition_minter_custom_template(params_extension, init_msg).unwrap();
+
     let (mut router, creator, buyer) = (vt.router, vt.accts.creator, vt.accts.buyer);
     let minter_addr = vt.collection_response_vec[0].minter.clone().unwrap();
     let collection_addr = vt.collection_response_vec[0].collection.clone().unwrap();
@@ -87,7 +96,7 @@ fn check_mint_revenues_distribution() {
     );
     assert_eq!(
         res.err().unwrap().source().unwrap().to_string(),
-        "IncorrectPaymentAmount 100ustars != 100000000ustars"
+        "Generic error: IncorrectPaymentAmount 100ustars != 100000000ustars"
     );
 
     // Invalid price
@@ -100,7 +109,7 @@ fn check_mint_revenues_distribution() {
     );
     assert_eq!(
         res.err().unwrap().source().unwrap().to_string(),
-        "IncorrectPaymentAmount 200000000ustars != 100000000ustars"
+        "Generic error: IncorrectPaymentAmount 200000000ustars != 100000000ustars"
     );
 
     // Invalid price
@@ -108,7 +117,7 @@ fn check_mint_revenues_distribution() {
     let res = router.execute_contract(buyer.clone(), minter_addr.clone(), &mint_msg, &[]);
     assert_eq!(
         res.err().unwrap().source().unwrap().to_string(),
-        "IncorrectPaymentAmount 0ustars != 100000000ustars"
+        "Generic error: IncorrectPaymentAmount 0ustars != 100000000ustars"
     );
 
     // Invalid denom
@@ -119,7 +128,7 @@ fn check_mint_revenues_distribution() {
                 amount: coins(100_000u128, "invalid".to_string()),
             }
         }))
-        .map_err(|err| println!("{err:?}"))
+        .map_err(|err| println!("{:?}", err))
         .ok();
     let mint_msg = ExecuteMsg::Mint {};
     let res = router.execute_contract(
@@ -130,7 +139,7 @@ fn check_mint_revenues_distribution() {
     );
     assert_eq!(
         res.err().unwrap().source().unwrap().to_string(),
-        "Received unsupported denom 'invalid'"
+        "Generic error: Received unsupported denom 'invalid'"
     );
 
     for _i in 1..=2 {

--- a/test-suite/src/open_edition_minter/tests/ibc_asset_mint.rs
+++ b/test-suite/src/open_edition_minter/tests/ibc_asset_mint.rs
@@ -1,24 +1,22 @@
 use base_factory::ContractError as BaseContractError;
-use cosmwasm_std::{coin, coins, Addr, Decimal, Uint128};
+use cosmwasm_std::{coin, Addr, Coin, Decimal, Uint128};
 use cw_multi_test::{BankSudo, Executor, SudoMsg};
-use open_edition_factory::types::{NftData, NftMetadataType};
+use open_edition_factory::{
+    state::{OpenEditionMinterParams, ParamsExtension},
+    types::{NftData, NftMetadataType},
+};
 use open_edition_minter::msg::ExecuteMsg;
-use sg2::{msg::Sg2ExecuteMsg, tests::mock_collection_params};
 use sg_std::{GENESIS_MINT_START_TIME, NATIVE_DENOM};
 
 use crate::common_setup::{
-    contract_boxes::{contract_sg721_base, custom_mock_app},
-    setup_accounts_and_block::{setup_accounts, setup_block_time},
+    setup_accounts_and_block::setup_block_time,
     setup_minter::{
-        common::constants::{CREATION_FEE, MIN_MINT_PRICE_OPEN_EDITION},
-        open_edition_minter::{
-            mock_params::{
-                mock_create_minter_init_msg, mock_init_minter_extension, mock_params_custom,
-            },
-            setup::open_edition_minter_code_ids,
+        common::constants::{
+            CREATION_FEE, DEV_ADDRESS, MINT_FEE_FAIR_BURN, MIN_MINT_PRICE_OPEN_EDITION,
         },
+        open_edition_minter::minter_params::{default_nft_data, init_msg},
     },
-    templates::{open_edition_minter_custom_template, OpenEditionMinterCustomParams},
+    templates::open_edition_minter_ibc_template,
 };
 
 #[test]
@@ -26,25 +24,43 @@ fn check_custom_create_minter_denom() {
     // allow ibc/frenz denom
     let denom = "ibc/frenz";
     let mint_price = coin(MIN_MINT_PRICE_OPEN_EDITION, denom.to_string());
-    let custom_params = OpenEditionMinterCustomParams {
-        denom: Some(denom),
-        ..OpenEditionMinterCustomParams::default()
+    let params_extension = ParamsExtension {
+        max_per_address_limit: 10,
+        airdrop_mint_fee_bps: 100,
+        airdrop_mint_price: Coin {
+            denom: denom.to_string(),
+            amount: Uint128::new(100_000_000u128),
+        },
+        dev_fee_address: DEV_ADDRESS.to_string(),
     };
-    let vt = open_edition_minter_custom_template(
+    let per_address_limit_minter = Some(2);
+    let init_msg = init_msg(
+        default_nft_data(),
+        per_address_limit_minter,
         None,
         None,
-        None,
-        Some(10),
-        Some(2),
         Some(mint_price.clone()),
-        custom_params,
-        None,
-        None,
-    )
-    .unwrap();
+    );
+    let custom_minter_params = OpenEditionMinterParams {
+        code_id: 1,
+        allowed_sg721_code_ids: vec![1, 3, 5, 6],
+        frozen: false,
+        creation_fee: coin(CREATION_FEE, NATIVE_DENOM),
+        min_mint_price: sg2::Fungible(init_msg.mint_price.clone()),
+        mint_fee_bps: MINT_FEE_FAIR_BURN,
+        max_trading_offset_secs: 60 * 60 * 24 * 7,
+        extension: ParamsExtension {
+            max_per_address_limit: 10,
+            airdrop_mint_fee_bps: 100,
+            dev_fee_address: DEV_ADDRESS.to_string(),
+            airdrop_mint_price: params_extension.airdrop_mint_price.clone(),
+        },
+    };
+    let vt =
+        open_edition_minter_ibc_template(params_extension, init_msg, custom_minter_params).unwrap();
+
     let (mut router, creator, buyer) = (vt.router, vt.accts.creator, vt.accts.buyer);
     let minter_addr = vt.collection_response_vec[0].minter.clone().unwrap();
-
     // give the buyer some of the IBC asset
     router
         .sudo(SudoMsg::Bank({
@@ -57,8 +73,7 @@ fn check_custom_create_minter_denom() {
         .ok();
 
     setup_block_time(&mut router, GENESIS_MINT_START_TIME + 100, None);
-
-    // Mint succeeds
+    //     // Mint succeeds
     let mint_msg = ExecuteMsg::Mint {};
     let res = router.execute_contract(buyer.clone(), minter_addr, &mint_msg, &[mint_price.clone()]);
     assert!(res.is_ok());
@@ -84,23 +99,41 @@ fn one_hundred_percent_burned_ibc_minter() {
     // allow ibc/frenz denom
     let denom = "ibc/frenz";
     let mint_price = coin(MIN_MINT_PRICE_OPEN_EDITION, denom.to_string());
-    let custom_params = OpenEditionMinterCustomParams {
-        denom: Some(denom),
-        mint_fee_bps: Some(10000),
-        airdrop_mint_price_amount: Some(Uint128::zero()),
+    let params_extension = ParamsExtension {
+        max_per_address_limit: 10,
+        airdrop_mint_fee_bps: 100,
+        airdrop_mint_price: Coin {
+            denom: denom.to_string(),
+            amount: Uint128::new(100_000_000u128),
+        },
+        dev_fee_address: DEV_ADDRESS.to_string(),
     };
-    let vt = open_edition_minter_custom_template(
+    let per_address_limit_minter = Some(2);
+    let init_msg = init_msg(
+        default_nft_data(),
+        per_address_limit_minter,
         None,
         None,
-        None,
-        Some(10),
-        Some(2),
         Some(mint_price.clone()),
-        custom_params,
-        None,
-        None,
-    )
-    .unwrap();
+    );
+
+    let custom_minter_params = OpenEditionMinterParams {
+        code_id: 1,
+        allowed_sg721_code_ids: vec![1, 3, 5, 6],
+        frozen: false,
+        creation_fee: coin(CREATION_FEE, NATIVE_DENOM),
+        min_mint_price: sg2::Fungible(init_msg.mint_price.clone()),
+        mint_fee_bps: 10000,
+        max_trading_offset_secs: 60 * 60 * 24 * 7,
+        extension: ParamsExtension {
+            max_per_address_limit: 10,
+            airdrop_mint_fee_bps: 100,
+            dev_fee_address: DEV_ADDRESS.to_string(),
+            airdrop_mint_price: params_extension.airdrop_mint_price.clone(),
+        },
+    };
+    let vt =
+        open_edition_minter_ibc_template(params_extension, init_msg, custom_minter_params).unwrap();
     let (mut router, creator, buyer) = (vt.router, vt.accts.creator, vt.accts.buyer);
     let minter_addr = vt.collection_response_vec[0].minter.clone().unwrap();
 
@@ -146,23 +179,42 @@ fn zero_mint_fee() {
     // allow ibc/frenz denom
     let denom = "ibc/frenz";
     let mint_price = coin(MIN_MINT_PRICE_OPEN_EDITION, denom.to_string());
-    let custom_params = OpenEditionMinterCustomParams {
-        denom: Some(denom),
-        mint_fee_bps: Some(0),
-        airdrop_mint_price_amount: Some(Uint128::zero()),
+
+    let params_extension = ParamsExtension {
+        max_per_address_limit: 10,
+        airdrop_mint_fee_bps: 100,
+        airdrop_mint_price: Coin {
+            denom: denom.to_string(),
+            amount: Uint128::new(100_000_000u128),
+        },
+        dev_fee_address: DEV_ADDRESS.to_string(),
     };
-    let vt = open_edition_minter_custom_template(
+    let per_address_limit_minter = Some(2);
+    let init_msg = init_msg(
+        default_nft_data(),
+        per_address_limit_minter,
         None,
         None,
-        None,
-        Some(10),
-        Some(2),
         Some(mint_price.clone()),
-        custom_params,
-        None,
-        None,
-    )
-    .unwrap();
+    );
+
+    let custom_minter_params = OpenEditionMinterParams {
+        code_id: 1,
+        allowed_sg721_code_ids: vec![1, 3, 5, 6],
+        frozen: false,
+        creation_fee: coin(CREATION_FEE, NATIVE_DENOM),
+        min_mint_price: sg2::Fungible(init_msg.mint_price.clone()),
+        mint_fee_bps: 0,
+        max_trading_offset_secs: 60 * 60 * 24 * 7,
+        extension: ParamsExtension {
+            max_per_address_limit: 10,
+            airdrop_mint_fee_bps: 100,
+            dev_fee_address: DEV_ADDRESS.to_string(),
+            airdrop_mint_price: params_extension.airdrop_mint_price.clone(),
+        },
+    };
+    let vt =
+        open_edition_minter_ibc_template(params_extension, init_msg, custom_minter_params).unwrap();
     let (mut router, _, buyer) = (vt.router, vt.accts.creator, vt.accts.buyer);
     let minter_addr = vt.collection_response_vec[0].minter.clone().unwrap();
 
@@ -189,50 +241,54 @@ fn zero_mint_fee() {
 fn denom_mismatch_creating_minter() {
     // create factory w NATIVE_DENOM, then try creating a minter w different denom
     let denom = "ibc/asset";
-    let mut app = custom_mock_app();
-    let (creator, _) = setup_accounts(&mut app);
-
     let mint_price = coin(MIN_MINT_PRICE_OPEN_EDITION, denom.to_string());
+    let mismatch_denom = coin(MIN_MINT_PRICE_OPEN_EDITION, NATIVE_DENOM);
     let nft_data = NftData {
         nft_data_type: NftMetadataType::OffChainMetadata,
         token_uri: Some("ipfs://1234".to_string()),
         extension: None,
     };
-    let code_ids = open_edition_minter_code_ids(&mut app, contract_sg721_base());
 
-    let minter_code_id = code_ids.minter_code_id;
-    let factory_code_id = code_ids.factory_code_id;
-    let sg721_code_id = code_ids.sg721_code_id;
-    let minter_admin = creator;
-
-    let mut params = mock_params_custom(OpenEditionMinterCustomParams::default());
-    params.code_id = minter_code_id;
-
-    let factory_addr = app
-        .instantiate_contract(
-            factory_code_id,
-            minter_admin.clone(),
-            &open_edition_factory::msg::InstantiateMsg { params },
-            &[],
-            "factory",
-            None,
-        )
-        .unwrap();
-
-    let mut init_msg =
-        mock_init_minter_extension(None, None, None, Some(mint_price.clone()), nft_data, None);
-    init_msg.mint_price = mint_price;
-    let mut msg = mock_create_minter_init_msg(mock_collection_params(), init_msg);
-    msg.collection_params.code_id = sg721_code_id;
-    msg.collection_params.info.creator = minter_admin.to_string();
-    let creation_fee = coins(CREATION_FEE, NATIVE_DENOM);
-    let msg = Sg2ExecuteMsg::CreateMinter(msg);
-
-    let err = app
-        .execute_contract(minter_admin, factory_addr, &msg, &creation_fee)
-        .unwrap_err();
-    assert_eq!(
-        err.source().unwrap().to_string(),
-        BaseContractError::InvalidDenom {}.to_string()
+    let params_extension = ParamsExtension {
+        max_per_address_limit: 10,
+        airdrop_mint_fee_bps: 100,
+        airdrop_mint_price: Coin {
+            denom: mint_price.to_string(),
+            amount: Uint128::new(100_000_000u128),
+        },
+        dev_fee_address: DEV_ADDRESS.to_string(),
+    };
+    let per_address_limit_minter = Some(2);
+    let init_msg = init_msg(
+        nft_data,
+        per_address_limit_minter,
+        None,
+        None,
+        Some(mint_price.clone()),
     );
+    let custom_minter_params = OpenEditionMinterParams {
+        code_id: 1,
+        allowed_sg721_code_ids: vec![1, 2, 3, 5, 6],
+        frozen: false,
+        creation_fee: coin(CREATION_FEE, NATIVE_DENOM),
+        min_mint_price: sg2::Fungible(mint_price),
+        mint_fee_bps: MINT_FEE_FAIR_BURN,
+        max_trading_offset_secs: 60 * 60 * 24 * 7,
+        extension: ParamsExtension {
+            max_per_address_limit: 10,
+            airdrop_mint_fee_bps: 100,
+            dev_fee_address: DEV_ADDRESS.to_string(),
+            airdrop_mint_price: mismatch_denom,
+        },
+    };
+
+    let vt =
+        open_edition_minter_ibc_template(params_extension, init_msg, custom_minter_params).unwrap();
+    let err = vt.collection_response_vec[0]
+        .error
+        .as_ref()
+        .unwrap()
+        .root_cause()
+        .to_string();
+    assert_eq!(err, BaseContractError::InvalidDenom {}.to_string());
 }

--- a/test-suite/src/open_edition_minter/tests/update_mint_price.rs
+++ b/test-suite/src/open_edition_minter/tests/update_mint_price.rs
@@ -1,30 +1,40 @@
 use cosmwasm_std::{Coin, Uint128};
 use cw_multi_test::Executor;
+use open_edition_factory::state::ParamsExtension;
 use sg_std::{GENESIS_MINT_START_TIME, NATIVE_DENOM};
 
 use open_edition_minter::msg::{ExecuteMsg, QueryMsg};
 
 use crate::common_setup::setup_accounts_and_block::setup_block_time;
-use crate::common_setup::templates::{
-    open_edition_minter_custom_template, OpenEditionMinterCustomParams,
+use crate::common_setup::setup_minter::common::constants::DEV_ADDRESS;
+use crate::common_setup::setup_minter::open_edition_minter::minter_params::{
+    default_nft_data, init_msg,
 };
+use crate::common_setup::templates::open_edition_minter_custom_template;
 
 const MINT_PRICE: u128 = 100_000_000;
 
 #[test]
 fn check_mint_price_updates() {
-    let vt = open_edition_minter_custom_template(
+    let params_extension = ParamsExtension {
+        max_per_address_limit: 10,
+        airdrop_mint_fee_bps: 100,
+        airdrop_mint_price: Coin {
+            denom: NATIVE_DENOM.to_string(),
+            amount: Uint128::new(100_000_000u128),
+        },
+        dev_fee_address: DEV_ADDRESS.to_string(),
+    };
+    let per_address_limit_minter = Some(2);
+    let init_msg = init_msg(
+        default_nft_data(),
+        per_address_limit_minter,
         None,
         None,
         None,
-        Some(10),
-        Some(2),
-        None,
-        OpenEditionMinterCustomParams::default(),
-        None,
-        None,
-    )
-    .unwrap();
+    );
+
+    let vt = open_edition_minter_custom_template(params_extension, init_msg).unwrap();
     let (mut router, creator, _buyer) = (vt.router, vt.accts.creator, vt.accts.buyer);
     let minter_addr = vt.collection_response_vec[0].minter.clone().unwrap();
 
@@ -41,6 +51,7 @@ fn check_mint_price_updates() {
             amount: Uint128::new(MINT_PRICE)
         }
     );
+
     assert_eq!(
         res.airdrop_price,
         Coin {

--- a/test-suite/src/open_edition_minter/tests/update_start_and_end_time.rs
+++ b/test-suite/src/open_edition_minter/tests/update_start_and_end_time.rs
@@ -1,28 +1,37 @@
-use cosmwasm_std::Timestamp;
+use cosmwasm_std::{Coin, Timestamp, Uint128};
 use cw_multi_test::Executor;
-use sg_std::GENESIS_MINT_START_TIME;
+use open_edition_factory::state::ParamsExtension;
+use sg_std::{GENESIS_MINT_START_TIME, NATIVE_DENOM};
 
 use open_edition_minter::msg::{EndTimeResponse, StartTimeResponse};
 use open_edition_minter::msg::{ExecuteMsg, QueryMsg};
 
-use crate::common_setup::templates::{
-    open_edition_minter_custom_template, OpenEditionMinterCustomParams,
+use crate::common_setup::setup_minter::common::constants::DEV_ADDRESS;
+use crate::common_setup::setup_minter::open_edition_minter::minter_params::{
+    default_nft_data, init_msg,
 };
+use crate::common_setup::templates::open_edition_minter_custom_template;
 
 #[test]
 fn check_start_end_time_updates() {
-    let vt = open_edition_minter_custom_template(
+    let params_extension = ParamsExtension {
+        max_per_address_limit: 10,
+        airdrop_mint_fee_bps: 100,
+        airdrop_mint_price: Coin {
+            denom: NATIVE_DENOM.to_string(),
+            amount: Uint128::new(100_000_000u128),
+        },
+        dev_fee_address: DEV_ADDRESS.to_string(),
+    };
+    let per_address_limit_minter = Some(2);
+    let init_msg = init_msg(
+        default_nft_data(),
+        per_address_limit_minter,
         None,
         None,
         None,
-        Some(10),
-        Some(2),
-        None,
-        OpenEditionMinterCustomParams::default(),
-        None,
-        None,
-    )
-    .unwrap();
+    );
+    let vt = open_edition_minter_custom_template(params_extension, init_msg).unwrap();
     let (mut router, creator, _buyer) = (vt.router, vt.accts.creator, vt.accts.buyer);
     let minter_addr = vt.collection_response_vec[0].minter.clone().unwrap();
 

--- a/test-suite/src/sg721_base/tests/integration_tests.rs
+++ b/test-suite/src/sg721_base/tests/integration_tests.rs
@@ -63,7 +63,7 @@ mod tests {
         let sg721_id = app.store_code(contract_sg721_base());
 
         let collection_params = mock_collection_params();
-        let mut m = mock_create_minter(None, collection_params, None);
+        let mut m = mock_create_minter(None, collection_params, None, None);
         m.collection_params.code_id = sg721_id;
         let msg = ExecuteMsg::CreateMinter(m);
 
@@ -817,7 +817,7 @@ mod tests {
             let sg721_id = app.store_code(contract_sg721_updatable());
 
             let collection_params = mock_collection_params();
-            let mut m = mock_create_minter(None, collection_params, None);
+            let mut m = mock_create_minter(None, collection_params, None, None);
             m.collection_params.code_id = sg721_id;
             let msg = ExecuteMsg::CreateMinter(m);
 

--- a/test-suite/src/sg_eth_airdrop/setup/configure_mock_minter.rs
+++ b/test-suite/src/sg_eth_airdrop/setup/configure_mock_minter.rs
@@ -40,7 +40,7 @@ fn configure_mock_minter(app: &mut StargazeApp, creator: Addr) {
         .unwrap();
     let start_time = Timestamp::from_nanos(GENESIS_MINT_START_TIME);
     let collection_params = mock_collection_params_1(Some(start_time));
-    let msg = mock_create_minter(None, collection_params, None);
+    let msg = mock_create_minter(None, collection_params, None, None);
     let msg = Sg2ExecuteMsg::CreateMinter(msg);
     let res = app.execute_contract(creator, factory_addr, &msg, &creation_fee);
     assert!(res.is_ok());

--- a/test-suite/src/vending_factory/tests.rs
+++ b/test-suite/src/vending_factory/tests.rs
@@ -1,1 +1,2 @@
 mod integration_tests;
+mod sudo_tests;

--- a/test-suite/src/vending_factory/tests/sudo_tests.rs
+++ b/test-suite/src/vending_factory/tests/sudo_tests.rs
@@ -1,0 +1,73 @@
+use base_factory::msg::ParamsResponse;
+use cosmwasm_std::{coin, Addr};
+use sg_std::NATIVE_DENOM;
+use vending_factory::msg::VendingUpdateParamsExtension;
+
+use crate::common_setup::msg::MinterCollectionResponse;
+use crate::common_setup::setup_minter::vending_minter::setup::sudo_update_params;
+use crate::common_setup::templates::vending_minter_template_with_code_ids_template;
+use sg2::query::Sg2QueryMsg::Params;
+
+#[test]
+fn happy_path_with_params_update() {
+    let vt = vending_minter_template_with_code_ids_template(2);
+    let (mut router, _, _) = (vt.router, vt.accts.creator, vt.accts.buyer);
+    sudo_update_params(&mut router, &vt.collection_response_vec, vt.code_ids, None);
+}
+
+#[test]
+fn sudo_params_update_invalid_nft_collection() {
+    let vt = vending_minter_template_with_code_ids_template(2);
+    let (mut router, _, _) = (vt.router, vt.accts.creator, vt.accts.buyer);
+    let mut response_collection_vec: Vec<MinterCollectionResponse> = vec![];
+    for entry in vt.collection_response_vec {
+        let new_entry = MinterCollectionResponse {
+            minter: entry.minter,
+            collection: Some(Addr::unchecked("fake_address")),
+            factory: entry.factory,
+            error: entry.error,
+        };
+        response_collection_vec.push(new_entry);
+    }
+    let sudo_responses =
+        sudo_update_params(&mut router, &response_collection_vec, vt.code_ids, None);
+    let sudo_response_1 = sudo_responses.first();
+    let err = sudo_response_1.unwrap().as_ref().unwrap_err().to_string();
+    assert_eq!(err, "InvalidCollectionAddress".to_string());
+}
+
+#[test]
+fn sudo_params_update_creation_fee() {
+    let vt = vending_minter_template_with_code_ids_template(2);
+    let (mut router, _, _) = (vt.router, vt.accts.creator, vt.accts.buyer);
+    let collection = vt.collection_response_vec[0].collection.clone().unwrap();
+    let factory = vt.collection_response_vec[0].factory.clone().unwrap();
+    let code_ids = vt.code_ids.clone();
+
+    let update_msg = sg2::msg::UpdateMinterParamsMsg {
+        code_id: Some(code_ids.sg721_code_id),
+        add_sg721_code_ids: None,
+        rm_sg721_code_ids: None,
+        frozen: None,
+        creation_fee: Some(coin(999, NATIVE_DENOM)),
+        min_mint_price: Some(sg2::NonFungible(collection.to_string())),
+        mint_fee_bps: None,
+        max_trading_offset_secs: Some(100),
+        extension: VendingUpdateParamsExtension {
+            max_token_limit: None,
+            max_per_address_limit: None,
+            airdrop_mint_price: None,
+            airdrop_mint_fee_bps: None,
+            shuffle_fee: None,
+        },
+    };
+    sudo_update_params(
+        &mut router,
+        &vt.collection_response_vec,
+        vt.code_ids,
+        Some(update_msg),
+    );
+
+    let res: ParamsResponse = router.wrap().query_wasm_smart(factory, &Params {}).unwrap();
+    assert_eq!(res.params.creation_fee, coin(999, NATIVE_DENOM));
+}

--- a/test-suite/src/vending_minter/tests.rs
+++ b/test-suite/src/vending_minter/tests.rs
@@ -1,5 +1,6 @@
 mod address_limit;
 mod allowed_code_ids;
+mod burn_to_mint;
 mod frozen_factory;
 mod happy_unhappy;
 mod ibc_asset_mint;

--- a/test-suite/src/vending_minter/tests/address_limit.rs
+++ b/test-suite/src/vending_minter/tests/address_limit.rs
@@ -314,6 +314,7 @@ fn mint_for_token_id_addr() {
     let minter_addr = vt.collection_response_vec[0].minter.clone().unwrap();
     let collection_addr = vt.collection_response_vec[0].collection.clone().unwrap();
     setup_block_time(&mut router, GENESIS_MINT_START_TIME, None);
+
     // Try mint_for, test unauthorized
     let mint_for_msg = ExecuteMsg::MintFor {
         token_id: 1,
@@ -431,11 +432,11 @@ fn mint_for_token_id_addr() {
         )
         .unwrap_err();
     assert_eq!(
-        ContractError::IncorrectPaymentAmount(
+        format!(
+            "Generic error: IncorrectPaymentAmount {} != {}",
             coin(ADMIN_MINT_PRICE + 1, NATIVE_DENOM.to_string()),
             coin(ADMIN_MINT_PRICE, NATIVE_DENOM.to_string())
-        )
-        .to_string(),
+        ),
         err.source().unwrap().to_string()
     );
 

--- a/test-suite/src/vending_minter/tests/allowed_code_ids.rs
+++ b/test-suite/src/vending_minter/tests/allowed_code_ids.rs
@@ -78,6 +78,7 @@ fn update_code_id() {
     let mut msg = VendingMinterCreateMsg {
         init_msg,
         collection_params,
+        allowed_burn_collections: None,
     };
     msg.collection_params.info.creator = creator.to_string();
     let creation_fee = coins(CREATION_FEE, NATIVE_DENOM);

--- a/test-suite/src/vending_minter/tests/burn_to_mint.rs
+++ b/test-suite/src/vending_minter/tests/burn_to_mint.rs
@@ -1,0 +1,124 @@
+use cosmwasm_std::Addr;
+use cosmwasm_std::{coin, to_binary};
+use cw721::{Cw721ExecuteMsg, Cw721QueryMsg};
+use cw_multi_test::Executor;
+use open_edition_minter::msg::ExecuteMsg;
+use sg_std::GENESIS_MINT_START_TIME;
+use sg_std::NATIVE_DENOM;
+
+use crate::common_setup::setup_accounts_and_block::setup_block_time;
+use crate::common_setup::templates::vending_minter_with_two_sg721_collections_burn_mint;
+
+#[test]
+fn check_burns_tokens_when_received() {
+    let allowed_burn_collections = vec![Addr::unchecked("contract2")];
+    let vt = vending_minter_with_two_sg721_collections_burn_mint(1, allowed_burn_collections);
+    let (mut router, creator) = (vt.router, vt.accts.creator);
+    let minter_addr_1 = vt.collection_response_vec[0].minter.clone().unwrap();
+    let collection_addr_1 = vt.collection_response_vec[0].collection.clone().unwrap();
+
+    let minter_addr_2 = vt.collection_response_vec[1].minter.clone().unwrap();
+
+    setup_block_time(&mut router, GENESIS_MINT_START_TIME + 101, None);
+
+    let mint_price = 100_000_000;
+    // Mint one NFT
+    let mint_msg = ExecuteMsg::Mint {};
+    let res = router.execute_contract(
+        creator.clone(),
+        minter_addr_1,
+        &mint_msg,
+        &[coin(mint_price, NATIVE_DENOM)],
+    );
+    assert!(res.is_ok());
+
+    let num_tokens_res: cw721::NumTokensResponse = router
+        .wrap()
+        .query_wasm_smart(collection_addr_1.clone(), &Cw721QueryMsg::NumTokens {})
+        .unwrap();
+    // one token after mint
+    assert_eq!(num_tokens_res.count, 1);
+
+    let send_nft = Cw721ExecuteMsg::SendNft {
+        contract: minter_addr_2.to_string(),
+        token_id: 1.to_string(),
+        msg: to_binary("this is a test").unwrap(),
+    };
+
+    let res = router.execute_contract(creator, collection_addr_1.clone(), &send_nft, &[]);
+    assert!(res.is_ok());
+
+    let num_tokens_res: cw721::NumTokensResponse = router
+        .wrap()
+        .query_wasm_smart(collection_addr_1, &Cw721QueryMsg::NumTokens {})
+        .unwrap();
+
+    // zero tokens after burn
+    assert_eq!(num_tokens_res.count, 0);
+}
+
+#[test]
+fn check_mints_new_tokens_when_received() {
+    let allowed_burn_collections = vec![Addr::unchecked("contract2")];
+    let vt = vending_minter_with_two_sg721_collections_burn_mint(1, allowed_burn_collections);
+    let (mut router, creator) = (vt.router, vt.accts.creator);
+    let minter_addr_1 = vt.collection_response_vec[0].minter.clone().unwrap();
+    let collection_addr_1 = vt.collection_response_vec[0].collection.clone().unwrap();
+
+    let minter_addr_2 = vt.collection_response_vec[1].minter.clone().unwrap();
+    let collection_addr_2 = vt.collection_response_vec[1].collection.clone().unwrap();
+
+    setup_block_time(&mut router, GENESIS_MINT_START_TIME + 101, None);
+
+    // Mint one NFT
+    let mint_price = 100_000_000;
+
+    let mint_msg = ExecuteMsg::Mint {};
+    let res = router.execute_contract(
+        creator.clone(),
+        minter_addr_1,
+        &mint_msg,
+        &[coin(mint_price, NATIVE_DENOM)],
+    );
+    assert!(res.is_ok());
+
+    let num_tokens_res: cw721::NumTokensResponse = router
+        .wrap()
+        .query_wasm_smart(collection_addr_1.clone(), &Cw721QueryMsg::NumTokens {})
+        .unwrap();
+    // one token after mint
+    assert_eq!(num_tokens_res.count, 1);
+
+    let num_tokens_res: cw721::NumTokensResponse = router
+        .wrap()
+        .query_wasm_smart(collection_addr_2.clone(), &Cw721QueryMsg::NumTokens {})
+        .unwrap();
+    // no tokens before mitning
+    assert_eq!(num_tokens_res.count, 0);
+
+    let send_nft = Cw721ExecuteMsg::SendNft {
+        contract: minter_addr_2.to_string(),
+        token_id: 1.to_string(),
+        msg: to_binary("this is a test").unwrap(),
+    };
+    let res = router.execute_contract(
+        creator,
+        collection_addr_1.clone(),
+        &send_nft,
+        &[coin(mint_price, NATIVE_DENOM)],
+    );
+    assert!(res.is_ok());
+    let num_tokens_res: cw721::NumTokensResponse = router
+        .wrap()
+        .query_wasm_smart(collection_addr_1, &Cw721QueryMsg::NumTokens {})
+        .unwrap();
+    // one token after mint
+    assert_eq!(num_tokens_res.count, 0);
+
+    let num_tokens_res: cw721::NumTokensResponse = router
+        .wrap()
+        .query_wasm_smart(collection_addr_2, &Cw721QueryMsg::NumTokens {})
+        .unwrap();
+    // one token after mint
+    assert_eq!(num_tokens_res.count, 1);
+}

--- a/test-suite/src/vending_minter/tests/frozen_factory.rs
+++ b/test-suite/src/vending_minter/tests/frozen_factory.rs
@@ -64,7 +64,7 @@ fn frozen_factory_cannot_create_new_minters() {
 
     // creating new minter throws error
     let start_time = Timestamp::from_nanos(GENESIS_MINT_START_TIME);
-    let mut msg = mock_create_minter(None, mock_collection_params(), Some(start_time));
+    let mut msg = mock_create_minter(None, mock_collection_params(), Some(start_time), None);
     msg.init_msg = build_init_msg(None, msg.clone(), num_tokens);
     msg.collection_params.info.creator = creator.to_string();
     let creation_fee = coins(CREATION_FEE, NATIVE_DENOM);

--- a/test-suite/src/vending_minter/tests/happy_unhappy.rs
+++ b/test-suite/src/vending_minter/tests/happy_unhappy.rs
@@ -36,7 +36,7 @@ fn initialization() {
 
     let start_time = Timestamp::from_nanos(GENESIS_MINT_START_TIME);
     let collection_params = mock_collection_params_1(Some(start_time));
-    let mut msg = mock_create_minter(None, collection_params.clone(), None);
+    let mut msg = mock_create_minter(None, collection_params.clone(), None, None);
     msg.init_msg.num_tokens = 100;
     msg.collection_params.code_id = 1;
     msg.collection_params.info.creator = info.sender.to_string();
@@ -51,7 +51,7 @@ fn initialization() {
     let wrong_denom = "uosmo";
     let info = mock_info("creator", &coins(INITIAL_BALANCE, NATIVE_DENOM));
     // let mut msg = minter_init();
-    let mut msg = mock_create_minter(None, collection_params.clone(), None);
+    let mut msg = mock_create_minter(None, collection_params.clone(), None, None);
     // msg.init_msg.mint_price = 100;
     msg.init_msg.mint_price = coin(MINT_PRICE, wrong_denom);
 
@@ -59,7 +59,7 @@ fn initialization() {
 
     // Insufficient mint price returns error
     let info = mock_info("creator", &coins(INITIAL_BALANCE, NATIVE_DENOM));
-    let mut msg = mock_create_minter(None, collection_params.clone(), None);
+    let mut msg = mock_create_minter(None, collection_params.clone(), None, None);
     msg.init_msg.mint_price = coin(1, NATIVE_DENOM);
 
     instantiate(deps.as_mut(), mock_env(), info, msg).unwrap_err();
@@ -67,7 +67,7 @@ fn initialization() {
     // Over max token limit
     let info = mock_info("creator", &coins(INITIAL_BALANCE, NATIVE_DENOM));
     // let mut msg = minter_init();
-    let mut msg = mock_create_minter(None, collection_params.clone(), None);
+    let mut msg = mock_create_minter(None, collection_params.clone(), None, None);
     msg.init_msg.mint_price = coin(MINT_PRICE, NATIVE_DENOM);
     msg.init_msg.num_tokens = MAX_TOKEN_LIMIT + 1;
 
@@ -76,7 +76,7 @@ fn initialization() {
     // Under min token limit
     let info = mock_info("creator", &coins(INITIAL_BALANCE, NATIVE_DENOM));
     // let mut msg = minter_init();
-    let mut msg = mock_create_minter(None, collection_params, None);
+    let mut msg = mock_create_minter(None, collection_params, None, None);
     msg.init_msg.num_tokens = 0;
 
     instantiate(deps.as_mut(), mock_env(), info, msg).unwrap_err();
@@ -86,9 +86,9 @@ fn initialization() {
 fn happy_path() {
     let vt = vending_minter_template(2);
     let (mut router, creator, buyer) = (vt.router, vt.accts.creator, vt.accts.buyer);
+
     let minter_addr = vt.collection_response_vec[0].minter.clone().unwrap();
     let collection_addr = vt.collection_response_vec[0].collection.clone().unwrap();
-
     // Default start time genesis mint time
     let res: StartTimeResponse = router
         .wrap()

--- a/test-suite/src/vending_minter/tests/splits.rs
+++ b/test-suite/src/vending_minter/tests/splits.rs
@@ -73,7 +73,8 @@ fn mint_and_split() {
     let (creator, buyer) = setup_accounts(&mut app);
     let num_tokens = 2;
     let start_time = Timestamp::from_nanos(GENESIS_MINT_START_TIME);
-    let minter_params = minter_params_all(num_tokens, Some(splits_addr.to_string()), None, None);
+    let minter_params =
+        minter_params_all(num_tokens, Some(splits_addr.to_string()), None, None, None);
     let collection_params = mock_collection_params_1(Some(start_time));
     let code_ids = vending_minter_code_ids(&mut app);
     let minter_collection_response: Vec<MinterCollectionResponse> = configure_minter(

--- a/test-suite/src/vending_minter/tests/trading_time.rs
+++ b/test-suite/src/vending_minter/tests/trading_time.rs
@@ -98,6 +98,7 @@ fn test_invalid_start_time() {
         splits_addr: None,
         start_time: Some(Timestamp::from_nanos(GENESIS_MINT_START_TIME - 100)),
         init_msg: None,
+        allowed_burn_collections: None,
     };
     let code_ids = vending_minter_code_ids(&mut router);
     let minter_collection_response: Vec<MinterCollectionResponse> = configure_minter(
@@ -125,6 +126,7 @@ fn test_invalid_start_time() {
         splits_addr: None,
         start_time: Some(minter_start_time),
         init_msg: None,
+        allowed_burn_collections: None,
     };
     let code_ids = vending_minter_code_ids(&mut router);
     let minter_collection_response: Vec<MinterCollectionResponse> = configure_minter(
@@ -152,6 +154,7 @@ fn test_invalid_start_time() {
         splits_addr: None,
         start_time: Some(minter_start_time),
         init_msg: None,
+        allowed_burn_collections: None,
     };
     let minter_collection_response: Vec<MinterCollectionResponse> = configure_minter(
         &mut router,
@@ -207,6 +210,7 @@ fn invalid_trading_time_during_init() {
         splits_addr: None,
         start_time: None,
         init_msg: None,
+        allowed_burn_collections: None,
     };
     let code_ids = vending_minter_code_ids(&mut router);
     let minter_collection_response: Vec<MinterCollectionResponse> = configure_minter(

--- a/test-suite/src/vending_minter/tests/trading_time_updatable.rs
+++ b/test-suite/src/vending_minter/tests/trading_time_updatable.rs
@@ -104,6 +104,7 @@ fn test_invalid_start_time() {
         splits_addr: None,
         start_time: Some(Timestamp::from_nanos(GENESIS_MINT_START_TIME - 100)),
         init_msg: None,
+        allowed_burn_collections: None,
     };
     let code_ids = vending_minter_code_ids(&mut router);
     let minter_collection_response: Vec<MinterCollectionResponse> = configure_minter(
@@ -131,6 +132,7 @@ fn test_invalid_start_time() {
         splits_addr: None,
         start_time: Some(minter_start_time),
         init_msg: None,
+        allowed_burn_collections: None,
     };
     let code_ids = vending_minter_code_ids(&mut router);
     let minter_collection_response: Vec<MinterCollectionResponse> = configure_minter(
@@ -158,6 +160,7 @@ fn test_invalid_start_time() {
         splits_addr: None,
         start_time: Some(minter_start_time),
         init_msg: None,
+        allowed_burn_collections: None,
     };
     let minter_collection_response: Vec<MinterCollectionResponse> = configure_minter(
         &mut router,
@@ -213,6 +216,7 @@ fn invalid_trading_time_during_init() {
         splits_addr: None,
         start_time: None,
         init_msg: None,
+        allowed_burn_collections: None,
     };
     let code_ids = vending_minter_code_ids(&mut router);
     let minter_collection_response: Vec<MinterCollectionResponse> = configure_minter(

--- a/test-suite/src/vending_minter/tests/whitelist.rs
+++ b/test-suite/src/vending_minter/tests/whitelist.rs
@@ -51,7 +51,7 @@ fn invalid_whitelist_instantiate() {
         whitelist: Some("invalid address".to_string()),
     };
 
-    let minter_params = minter_params_all(num_tokens, None, None, Some(init_msg));
+    let minter_params = minter_params_all(num_tokens, None, None, Some(init_msg), None);
     let code_ids = vending_minter_code_ids(&mut router);
     let minter_collection_response = configure_minter(
         &mut router,

--- a/test-suite/src/vending_minter/tests/zero_mint_price.rs
+++ b/test-suite/src/vending_minter/tests/zero_mint_price.rs
@@ -38,7 +38,7 @@ fn zero_mint_price() {
         whitelist: Some("invalid address".to_string()),
     };
 
-    let minter_params = minter_params_all(num_tokens, None, None, Some(init_msg));
+    let minter_params = minter_params_all(num_tokens, None, None, Some(init_msg), None);
     let code_ids = vending_minter_code_ids(&mut app);
 
     let setup_params: MinterSetupParams = MinterSetupParams {
@@ -52,6 +52,7 @@ fn zero_mint_price() {
         sg721_code_id: code_ids.sg721_code_id,
         start_time: minter_params.start_time,
         init_msg: minter_params.init_msg,
+        allowed_burn_collections: None,
     };
 
     let minter_code_id = setup_params.minter_code_id;
@@ -62,7 +63,7 @@ fn zero_mint_price() {
 
     let mut params = mock_params(None);
     params.code_id = minter_code_id;
-    params.min_mint_price = coin(MINT_PRICE, NATIVE_DENOM);
+    params.min_mint_price = sg2::Fungible(coin(MINT_PRICE, NATIVE_DENOM));
 
     let factory_addr = router
         .instantiate_contract(
@@ -128,7 +129,7 @@ fn zero_wl_mint_price() {
         whitelist: Some("invalid address".to_string()),
     };
 
-    let minter_params = minter_params_all(num_tokens, None, None, Some(init_msg));
+    let minter_params = minter_params_all(num_tokens, None, None, Some(init_msg), None);
     let code_ids = vending_minter_code_ids(&mut app);
 
     let setup_params: MinterSetupParams = MinterSetupParams {
@@ -142,6 +143,7 @@ fn zero_wl_mint_price() {
         sg721_code_id: code_ids.sg721_code_id,
         start_time: minter_params.start_time,
         init_msg: minter_params.init_msg,
+        allowed_burn_collections: None,
     };
 
     let minter_code_id = setup_params.minter_code_id;
@@ -152,7 +154,7 @@ fn zero_wl_mint_price() {
 
     let mut params = mock_params(None);
     params.code_id = minter_code_id;
-    params.min_mint_price = coin(MINT_PRICE, NATIVE_DENOM);
+    params.min_mint_price = sg2::Fungible(coin(MINT_PRICE, NATIVE_DENOM));
 
     let factory_addr = router
         .instantiate_contract(
@@ -225,7 +227,7 @@ fn zero_wl_mint_errs_with_min_mint_factory() {
         whitelist: None,
     };
 
-    let minter_params = minter_params_all(num_tokens, None, None, Some(init_msg));
+    let minter_params = minter_params_all(num_tokens, None, None, Some(init_msg), None);
     let code_ids = vending_minter_code_ids(&mut app);
 
     let setup_params: MinterSetupParams = MinterSetupParams {
@@ -239,6 +241,7 @@ fn zero_wl_mint_errs_with_min_mint_factory() {
         sg721_code_id: code_ids.sg721_code_id,
         start_time: minter_params.start_time,
         init_msg: minter_params.init_msg,
+        allowed_burn_collections: None,
     };
 
     let minter_code_id = setup_params.minter_code_id;
@@ -249,7 +252,7 @@ fn zero_wl_mint_errs_with_min_mint_factory() {
 
     let mut params = mock_params(None);
     params.code_id = minter_code_id;
-    params.min_mint_price = coin(min_mint_price, NATIVE_DENOM);
+    params.min_mint_price = sg2::Fungible(coin(min_mint_price, NATIVE_DENOM));
 
     let factory_addr = router
         .instantiate_contract(


### PR DESCRIPTION
Please see https://github.com/public-awesome/launchpad/pull/585 for previous branch. 

Closed previous branch because commit history was causing errors when rebase main. 


This PR has several modules to it: 
1) Fungible and Nonfungible msg types in sg2: 
```rs
pub enum Token {
    Fungible(Coin),
    NonFungible(String),
}
```
2) The branching logic to check if receiving fungible or nonfungible token in contracts. All of the use of mint price through contracts and factories had to be changed to support this. Usually this is done implicitly in the .amount() checks. For example:
```rs
let config_mint_price = config.mint_price.clone().amount()?;
```
The amount() function has an implicit check: 
```rs
    pub fn amount(self) -> Result<Uint128, StdError> {
        let amount = match self {
            Token::Fungible(coin) => coin.amount,
            Token::NonFungible(_) => {
                return Err(StdError::generic_err("non-fungible tokens have no amount"))
            }
        };
        Ok(amount)
    }
}

```
3) Refactor of open edition minter tests: The open edition minter tests were in a bad state, so I refactored them to be more consistent. The files changed are the following: 

```rs
test-suite/src/common_setup/templates.rs
* in test-suite/src/open_edition_factory/
* in test-suite/src/open_edition_minter
* in test-suite/src/common_setup/setup_minter/open_edition_minter/
test-suite/src/common_setup/setup_minter/open_edition_minter.rs
```

4) Missing sudo tests: there was not sufficient tests for sudo update params so I added them in the following files: 

```rs
test-suite/src/base_factory/tests/sudo_tests.rs
test-suite/src/open_edition_factory/tests/sudo_tests.rs
test-suite/src/vending_factory/tests/sudo_tests.rs
```

5) Updates to minters: All three minters base-minter, vending-minter and open-edition minter had the following changes: 
- Add a  ReceiveNft(Cw721ReceiveMsg) path to execute
- Add a `execute_burn_to_mint` function to respond to the receive NFT message
- Updates to execute_mint functions to accomodate for not paying a mint fee when an NFT is received (collection contract will be calling itself)

6) `check_minter_caller` added to s721-base: We need this assertion check because, when an NFT is received, that contract will burn that NFT and then itself call a collection for a mint. The check minter caller, allows an sg721-base collection to call itself. 

7) burn_to_mint tests: burn_to_mint.rs was added to vending-minter, open-edition-minter and base-minter tests. A send nft is sent like so: 
```rs
    let send_nft = Cw721ExecuteMsg::SendNft {
        contract: minter_addr_2.to_string(),
        token_id: 1.to_string(),
        msg: to_binary("this is a test").unwrap(),
    };
    ```
    The message is sent to collection 1, with instructions to have collection 1 forward that NFT to minter 2. In this way, the functionality of burn to mint is tested end to end. 