### PR TITLE
Refactor Open Edition Minter Tests + Sudo Tests

### DIFF
--- a/test-suite/src/base_factory/tests.rs
+++ b/test-suite/src/base_factory/tests.rs
@@ -1,1 +1,2 @@
 mod integration_tests;
+mod sudo_tests;

--- a/test-suite/src/base_factory/tests/sudo_tests.rs
+++ b/test-suite/src/base_factory/tests/sudo_tests.rs
@@ -1,0 +1,44 @@
+use base_factory::msg::ParamsResponse;
+use cosmwasm_std::coin;
+use sg_std::NATIVE_DENOM;
+
+use crate::common_setup::setup_minter::base_minter::mock_params::MIN_MINT_PRICE;
+use crate::common_setup::setup_minter::base_minter::setup::sudo_update_params;
+use crate::common_setup::templates::base_minter_with_sudo_update_params_template;
+use sg2::query::Sg2QueryMsg::Params;
+
+#[test]
+fn happy_path_with_params_update() {
+    let vt = base_minter_with_sudo_update_params_template(2);
+    let (mut router, _, _) = (vt.router, vt.accts.creator, vt.accts.buyer);
+    sudo_update_params(&mut router, &vt.collection_response_vec, vt.code_ids, None);
+}
+
+#[test]
+fn sudo_params_update_creation_fee() {
+    let vt = base_minter_with_sudo_update_params_template(2);
+    let (mut router, _, _) = (vt.router, vt.accts.creator, vt.accts.buyer);
+    let factory = vt.collection_response_vec[0].factory.clone().unwrap();
+    let code_ids = vt.code_ids.clone();
+    use cosmwasm_std::Empty;
+    let update_msg = sg2::msg::UpdateMinterParamsMsg {
+        code_id: Some(code_ids.sg721_code_id),
+        add_sg721_code_ids: None,
+        rm_sg721_code_ids: None,
+        frozen: None,
+        creation_fee: Some(coin(999, NATIVE_DENOM)),
+        min_mint_price: Some(coin(MIN_MINT_PRICE, NATIVE_DENOM)),
+        mint_fee_bps: None,
+        max_trading_offset_secs: Some(100),
+        extension: Empty {},
+    };
+    sudo_update_params(
+        &mut router,
+        &vt.collection_response_vec,
+        vt.code_ids,
+        Some(update_msg),
+    );
+
+    let res: ParamsResponse = router.wrap().query_wasm_smart(factory, &Params {}).unwrap();
+    assert_eq!(res.params.creation_fee, coin(999, NATIVE_DENOM));
+}

--- a/test-suite/src/common_setup/msg.rs
+++ b/test-suite/src/common_setup/msg.rs
@@ -1,6 +1,8 @@
 use anyhow::Error;
 use cosmwasm_std::{Addr, Timestamp};
 
+use cosmwasm_std::Uint128;
+use open_edition_factory::state::{OpenEditionMinterParams, ParamsExtension};
 use sg2::msg::CollectionParams;
 use sg_multi_test::StargazeApp;
 use vending_factory::msg::VendingMinterInitMsgExtension;
@@ -48,6 +50,13 @@ pub struct MinterTemplateResponse<T> {
     pub accts: T,
 }
 
+pub struct MinterTemplateResponseCodeIds<T> {
+    pub collection_response_vec: Vec<MinterCollectionResponse>,
+    pub router: StargazeApp,
+    pub accts: T,
+    pub code_ids: CodeIds,
+}
+
 pub struct Accounts {
     pub creator: Addr,
     pub buyer: Addr,
@@ -65,6 +74,7 @@ pub struct OpenEditionMinterSetupParams<'a> {
     pub factory_code_id: u64,
     pub sg721_code_id: u64,
     pub init_msg: Option<OpenEditionMinterInitMsgExtension>,
+    pub custom_params: Option<OpenEditionMinterParams>,
 }
 
 pub struct OpenEditionMinterInstantiateParams {
@@ -73,4 +83,13 @@ pub struct OpenEditionMinterInstantiateParams {
     pub per_address_limit: Option<u32>,
     pub nft_data: Option<NftData>,
     pub init_msg: Option<OpenEditionMinterInitMsgExtension>,
+    pub params_extension: Option<ParamsExtension>,
+    pub custom_params: Option<OpenEditionMinterParams>,
+}
+
+#[derive(Default)]
+pub struct OpenEditionMinterCustomParams<'a> {
+    pub denom: Option<&'a str>,
+    pub mint_fee_bps: Option<u64>,
+    pub airdrop_mint_price_amount: Option<Uint128>,
 }

--- a/test-suite/src/common_setup/setup_minter/open_edition_minter.rs
+++ b/test-suite/src/common_setup/setup_minter/open_edition_minter.rs
@@ -1,2 +1,3 @@
+pub mod minter_params;
 pub mod mock_params;
 pub mod setup;

--- a/test-suite/src/common_setup/setup_minter/open_edition_minter/minter_params.rs
+++ b/test-suite/src/common_setup/setup_minter/open_edition_minter/minter_params.rs
@@ -1,0 +1,77 @@
+use cosmwasm_std::{Coin, Timestamp, Uint128};
+use open_edition_factory::{
+    msg::OpenEditionMinterInitMsgExtension,
+    state::{OpenEditionMinterParams, ParamsExtension},
+    types::{NftData, NftMetadataType},
+};
+use sg_std::{GENESIS_MINT_START_TIME, NATIVE_DENOM};
+
+use super::mock_params::mock_init_minter_extension;
+use crate::common_setup::{
+    msg::OpenEditionMinterInstantiateParams,
+    setup_minter::common::constants::MIN_MINT_PRICE_OPEN_EDITION,
+};
+
+pub fn minter_params_open_edition(
+    params_extension: ParamsExtension,
+    init_msg: OpenEditionMinterInitMsgExtension,
+    start_time: Option<Timestamp>,
+    end_time: Option<Timestamp>,
+    nft_data: Option<NftData>,
+    custom_params: Option<OpenEditionMinterParams>,
+) -> OpenEditionMinterInstantiateParams {
+    let start_time = start_time.unwrap_or(Timestamp::from_nanos(GENESIS_MINT_START_TIME + 100));
+    let end_time = end_time.unwrap_or(Timestamp::from_nanos(GENESIS_MINT_START_TIME + 10_000));
+
+    OpenEditionMinterInstantiateParams {
+        start_time: Some(start_time),
+        end_time: Some(end_time),
+        per_address_limit: Some(init_msg.per_address_limit),
+        nft_data: Some(
+            nft_data.unwrap_or(NftData {
+                nft_data_type: NftMetadataType::OffChainMetadata,
+                extension: None,
+                token_uri: Some(
+                    "ipfs://bafybeiavall5udkxkdtdm4djezoxrmfc6o5fn2ug3ymrlvibvwmwydgrkm/1.jpg"
+                        .to_string(),
+                ),
+            }),
+        ),
+        init_msg: Some(init_msg),
+        params_extension: Some(params_extension),
+        custom_params,
+    }
+}
+
+pub fn default_nft_data() -> NftData {
+    NftData {
+        nft_data_type: NftMetadataType::OffChainMetadata,
+        extension: None,
+        token_uri: Some(
+            "ipfs://bafybeiavall5udkxkdtdm4djezoxrmfc6o5fn2ug3ymrlvibvwmwydgrkm/1.jpg".to_string(),
+        ),
+    }
+}
+
+pub fn init_msg(
+    nft_data: NftData,
+    per_address_limit_minter: Option<u32>,
+    start_time: Option<Timestamp>,
+    end_time: Option<Timestamp>,
+    mint_price: Option<Coin>,
+) -> OpenEditionMinterInitMsgExtension {
+    let start_time = start_time.unwrap_or(Timestamp::from_nanos(GENESIS_MINT_START_TIME + 100));
+    let end_time = end_time.unwrap_or(Timestamp::from_nanos(GENESIS_MINT_START_TIME + 10_000));
+    let mint_price = mint_price.unwrap_or(Coin {
+        denom: NATIVE_DENOM.to_string(),
+        amount: Uint128::new(MIN_MINT_PRICE_OPEN_EDITION),
+    });
+    mock_init_minter_extension(
+        Some(start_time),
+        Some(end_time),
+        per_address_limit_minter,
+        Some(mint_price),
+        nft_data,
+        None,
+    )
+}

--- a/test-suite/src/common_setup/setup_minter/open_edition_minter/mock_params.rs
+++ b/test-suite/src/common_setup/setup_minter/open_edition_minter/mock_params.rs
@@ -7,10 +7,10 @@ use open_edition_factory::{
 use sg2::msg::CollectionParams;
 use sg_std::{GENESIS_MINT_START_TIME, NATIVE_DENOM};
 
+use crate::common_setup::msg::OpenEditionMinterCustomParams;
 use crate::common_setup::setup_minter::common::constants::{
     CREATION_FEE, DEV_ADDRESS, MINT_FEE_FAIR_BURN, MIN_MINT_PRICE_OPEN_EDITION,
 };
-use crate::common_setup::templates::OpenEditionMinterCustomParams;
 
 pub fn mock_init_minter_extension(
     start_time: Option<Timestamp>,
@@ -23,13 +23,14 @@ pub fn mock_init_minter_extension(
     OpenEditionMinterInitMsgExtension {
         nft_data,
         start_time: start_time.unwrap_or(Timestamp::from_nanos(GENESIS_MINT_START_TIME)),
-        mint_price: mint_price.unwrap_or(coin(MIN_MINT_PRICE_OPEN_EDITION, NATIVE_DENOM)),
+        mint_price: mint_price.unwrap_or_else(|| coin(MIN_MINT_PRICE_OPEN_EDITION, NATIVE_DENOM)),
         per_address_limit: per_address_limit_minter.unwrap_or(1u32),
         end_time: end_time.unwrap_or(Timestamp::from_nanos(GENESIS_MINT_START_TIME + 10_000)),
         payment_address,
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn mock_create_minter(
     start_time: Option<Timestamp>,
     end_time: Option<Timestamp>,
@@ -62,6 +63,26 @@ pub fn mock_create_minter_init_msg(
     }
 }
 
+pub fn mock_params_proper() -> OpenEditionMinterParams {
+    OpenEditionMinterParams {
+        code_id: 1,
+        allowed_sg721_code_ids: vec![1, 3, 5, 6],
+        frozen: false,
+        creation_fee: coin(CREATION_FEE, NATIVE_DENOM),
+        min_mint_price: coin(MIN_MINT_PRICE_OPEN_EDITION, NATIVE_DENOM),
+        mint_fee_bps: MINT_FEE_FAIR_BURN,
+        max_trading_offset_secs: 60 * 60 * 24 * 7,
+        extension: ParamsExtension {
+            max_per_address_limit: 10,
+            airdrop_mint_fee_bps: 100,
+            airdrop_mint_price: Coin {
+                denom: NATIVE_DENOM.to_string(),
+                amount: Uint128::new(100_000_000u128),
+            },
+            dev_fee_address: DEV_ADDRESS.to_string(),
+        },
+    }
+}
 // Pass custom params to change minter values
 pub fn mock_params_custom(custom_params: OpenEditionMinterCustomParams) -> OpenEditionMinterParams {
     let denom = custom_params.denom.unwrap_or(NATIVE_DENOM);
@@ -84,6 +105,27 @@ pub fn mock_params_custom(custom_params: OpenEditionMinterCustomParams) -> OpenE
                 denom: denom.to_string(),
                 amount: airdrop_mint_price_amount,
             },
+            dev_fee_address: DEV_ADDRESS.to_string(),
+        },
+    }
+}
+
+pub fn mock_params_custom_min_mint_price(
+    min_mint_price: Coin,
+    airdrop_mint_price: Coin,
+) -> OpenEditionMinterParams {
+    OpenEditionMinterParams {
+        code_id: 1,
+        allowed_sg721_code_ids: vec![1, 3, 5, 6],
+        frozen: false,
+        creation_fee: coin(CREATION_FEE, NATIVE_DENOM),
+        min_mint_price,
+        mint_fee_bps: MINT_FEE_FAIR_BURN,
+        max_trading_offset_secs: 60 * 60 * 24 * 7,
+        extension: ParamsExtension {
+            max_per_address_limit: 10,
+            airdrop_mint_fee_bps: 100,
+            airdrop_mint_price,
             dev_fee_address: DEV_ADDRESS.to_string(),
         },
     }

--- a/test-suite/src/common_setup/setup_minter/open_edition_minter/setup.rs
+++ b/test-suite/src/common_setup/setup_minter/open_edition_minter/setup.rs
@@ -1,22 +1,25 @@
 use crate::common_setup::contract_boxes::{
-    contract_open_edition_factory, contract_open_edition_minter,
+    contract_open_edition_factory, contract_open_edition_minter, contract_sg721_base,
 };
 use crate::common_setup::msg::{
     MinterCollectionResponse, OpenEditionMinterInstantiateParams, OpenEditionMinterSetupParams,
 };
+use crate::common_setup::setup_minter::base_minter::mock_params::MIN_MINT_PRICE;
 use crate::common_setup::setup_minter::common::parse_response::build_collection_response;
-use crate::common_setup::templates::OpenEditionMinterCustomParams;
-use cosmwasm_std::{coins, Addr, Coin, Timestamp};
-use cw_multi_test::{Contract, Executor};
-use open_edition_factory::msg::OpenEditionMinterInitMsgExtension;
+use anyhow::Error;
+use cosmwasm_std::{coin, coins, to_binary, Addr, Coin, Timestamp};
+use cw_multi_test::{AppResponse, Executor};
+use open_edition_factory::msg::{
+    OpenEditionMinterInitMsgExtension, OpenEditionUpdateParamsExtension, OpenEditionUpdateParamsMsg,
+};
 use open_edition_factory::types::NftData;
 use sg2::msg::{CollectionParams, Sg2ExecuteMsg};
 use sg_multi_test::StargazeApp;
-use sg_std::{StargazeMsgWrapper, NATIVE_DENOM};
+use sg_std::NATIVE_DENOM;
 
 use crate::common_setup::msg::CodeIds;
 use crate::common_setup::setup_minter::open_edition_minter::mock_params::{
-    mock_create_minter, mock_init_minter_extension, mock_params_custom,
+    mock_create_minter, mock_init_minter_extension, mock_params_proper,
 };
 
 use crate::common_setup::setup_minter::common::constants::CREATION_FEE;
@@ -58,12 +61,12 @@ pub fn setup_open_edition_minter_contract(
     let init_msg = setup_params.init_msg.clone();
     let nft_data = setup_params.init_msg.unwrap().nft_data;
 
-    let custom_params = OpenEditionMinterCustomParams {
-        denom: None,
-        mint_fee_bps: None,
-        airdrop_mint_price_amount: None,
+    let custom_params = setup_params.custom_params;
+
+    let mut params = mock_params_proper();
+    if let Some(custom_params) = custom_params {
+        params = custom_params;
     };
-    let mut params = mock_params_custom(custom_params);
     params.code_id = minter_code_id;
 
     let factory_addr = router.instantiate_contract(
@@ -76,12 +79,12 @@ pub fn setup_open_edition_minter_contract(
         "factory",
         None,
     );
-
-    let factory_addr = factory_addr.unwrap();
+    let min_mint_price = params.min_mint_price.amount;
+    let denom = params.min_mint_price.denom;
     let mut msg = mock_create_minter(
         start_time,
         end_time,
-        Some(params.min_mint_price.clone()),
+        Some(coin(min_mint_price.u128(), denom.clone())),
         Some(params.extension.max_per_address_limit),
         nft_data.clone(),
         collection_params,
@@ -93,33 +96,83 @@ pub fn setup_open_edition_minter_contract(
         end_time,
         Some(params.extension.max_per_address_limit),
         nft_data,
-        Some(params.min_mint_price),
+        Some(coin(min_mint_price.u128(), denom)),
         None,
     );
     msg.collection_params.code_id = sg721_code_id;
     msg.collection_params.info.creator = minter_admin.to_string();
+
     let creation_fee = coins(CREATION_FEE, NATIVE_DENOM);
     let msg = Sg2ExecuteMsg::CreateMinter(msg);
-
-    let res = router.execute_contract(minter_admin, factory_addr.clone(), &msg, &creation_fee);
-    build_collection_response(res, factory_addr)
+    match factory_addr {
+        Ok(addr) => {
+            let res = router.execute_contract(minter_admin, addr.clone(), &msg, &creation_fee);
+            build_collection_response(res, addr)
+        }
+        Err(e) => MinterCollectionResponse {
+            minter: None,
+            collection: None,
+            factory: None,
+            error: Some(e),
+        },
+    }
 }
 
-pub fn open_edition_minter_code_ids(
-    router: &mut StargazeApp,
-    sg721_code: Box<dyn Contract<StargazeMsgWrapper>>,
-) -> CodeIds {
+pub fn open_edition_minter_code_ids(router: &mut StargazeApp) -> CodeIds {
     let minter_code_id = router.store_code(contract_open_edition_minter());
 
     let factory_code_id = router.store_code(contract_open_edition_factory());
 
-    let sg721_code_id = router.store_code(sg721_code);
+    let sg721_code_id = router.store_code(contract_sg721_base());
 
     CodeIds {
         minter_code_id,
         factory_code_id,
         sg721_code_id,
     }
+}
+
+pub fn sudo_update_params(
+    app: &mut StargazeApp,
+    collection_responses: &Vec<MinterCollectionResponse>,
+    code_ids: CodeIds,
+    update_msg: Option<OpenEditionUpdateParamsMsg>,
+) -> Vec<Result<AppResponse, anyhow::Error>> {
+    let mut sudo_responses: Vec<Result<AppResponse, Error>> = vec![];
+    for collection_response in collection_responses {
+        let update_msg = match update_msg.clone() {
+            Some(some_update_message) => some_update_message,
+            None => OpenEditionUpdateParamsMsg {
+                code_id: Some(code_ids.sg721_code_id),
+                add_sg721_code_ids: None,
+                rm_sg721_code_ids: None,
+                frozen: None,
+                creation_fee: Some(coin(0, NATIVE_DENOM)),
+                min_mint_price: Some(Coin {
+                    amount: MIN_MINT_PRICE.into(),
+                    denom: NATIVE_DENOM.into(),
+                }),
+                mint_fee_bps: None,
+                max_trading_offset_secs: Some(100),
+                extension: OpenEditionUpdateParamsExtension {
+                    min_mint_price: None,
+                    dev_fee_address: None,
+                    max_per_address_limit: None,
+                    airdrop_mint_price: None,
+                    airdrop_mint_fee_bps: None,
+                },
+            },
+        };
+        let sudo_update_msg =
+            open_edition_factory::msg::SudoMsg::UpdateParams(Box::new(update_msg));
+
+        let sudo_res = app.sudo(cw_multi_test::SudoMsg::Wasm(cw_multi_test::WasmSudo {
+            contract_addr: collection_response.factory.clone().unwrap(),
+            msg: to_binary(&sudo_update_msg).unwrap(),
+        }));
+        sudo_responses.push(sudo_res);
+    }
+    sudo_responses
 }
 
 pub fn configure_open_edition_minter(
@@ -149,6 +202,7 @@ pub fn configure_open_edition_minter(
                 .unwrap(),
             init_msg: minter_instantiate_params_vec[index].init_msg.clone(),
             end_time: minter_instantiate_params_vec[index].end_time.to_owned(),
+            custom_params: minter_instantiate_params_vec[index].custom_params.clone(),
         };
         let minter_collection_res = setup_open_edition_minter_contract(setup_params);
         minter_collection_info.push(minter_collection_res);

--- a/test-suite/src/common_setup/setup_minter/vending_minter/setup.rs
+++ b/test-suite/src/common_setup/setup_minter/vending_minter/setup.rs
@@ -4,14 +4,15 @@ use crate::common_setup::contract_boxes::{
 };
 use crate::common_setup::msg::MinterCollectionResponse;
 use crate::common_setup::msg::MinterSetupParams;
+use crate::common_setup::setup_minter::base_minter::mock_params::MIN_MINT_PRICE;
 use crate::common_setup::setup_minter::common::parse_response::build_collection_response;
-use cosmwasm_std::{coin, coins, Addr};
-use cw_multi_test::Executor;
+use cosmwasm_std::{coin, coins, to_binary, Addr};
+use cw_multi_test::{AppResponse, Executor};
 use sg2::msg::CreateMinterMsg;
 use sg2::msg::{CollectionParams, Sg2ExecuteMsg};
 use sg_multi_test::StargazeApp;
 use sg_std::NATIVE_DENOM;
-use vending_factory::msg::VendingMinterInitMsgExtension;
+use vending_factory::msg::{VendingMinterInitMsgExtension, VendingUpdateParamsExtension};
 
 use crate::common_setup::msg::{CodeIds, MinterInstantiateParams};
 use crate::common_setup::setup_minter::vending_minter::mock_params::{
@@ -133,4 +134,43 @@ pub fn configure_minter(
         minter_collection_info.push(minter_collection_res);
     }
     minter_collection_info
+}
+
+pub fn sudo_update_params(
+    app: &mut StargazeApp,
+    collection_responses: &Vec<MinterCollectionResponse>,
+    code_ids: CodeIds,
+    update_msg: Option<sg2::msg::UpdateMinterParamsMsg<VendingUpdateParamsExtension>>,
+) -> Vec<Result<AppResponse, anyhow::Error>> {
+    let mut sudo_responses: Vec<Result<AppResponse, anyhow::Error>> = vec![];
+    for collection_response in collection_responses {
+        let update_msg = match update_msg.clone() {
+            Some(some_update_message) => some_update_message,
+            None => sg2::msg::UpdateMinterParamsMsg {
+                code_id: Some(code_ids.sg721_code_id),
+                add_sg721_code_ids: None,
+                rm_sg721_code_ids: None,
+                frozen: None,
+                creation_fee: Some(coin(0, NATIVE_DENOM)),
+                min_mint_price: Some(coin(MIN_MINT_PRICE, NATIVE_DENOM)),
+                mint_fee_bps: None,
+                max_trading_offset_secs: Some(100),
+                extension: VendingUpdateParamsExtension {
+                    max_token_limit: None,
+                    max_per_address_limit: None,
+                    airdrop_mint_price: None,
+                    airdrop_mint_fee_bps: None,
+                    shuffle_fee: None,
+                },
+            },
+        };
+        let sudo_update_msg = vending_factory::msg::SudoMsg::UpdateParams(Box::new(update_msg));
+
+        let sudo_res = app.sudo(cw_multi_test::SudoMsg::Wasm(cw_multi_test::WasmSudo {
+            contract_addr: collection_response.factory.clone().unwrap(),
+            msg: to_binary(&sudo_update_msg).unwrap(),
+        }));
+        sudo_responses.push(sudo_res);
+    }
+    sudo_responses
 }

--- a/test-suite/src/common_setup/templates.rs
+++ b/test-suite/src/common_setup/templates.rs
@@ -554,38 +554,3 @@ pub fn open_edition_minter_ibc_template(
         code_ids,
     })
 }
-
-// pub fn open_edition_minter_ibc_template_custom_code_ids(
-//     params_extension: ParamsExtension,
-//     init_msg: OpenEditionMinterInitMsgExtension,
-//     custom_minter_params: OpenEditionMinterParams,
-//     code_ids: CodeIds,
-// ) -> Result<MinterTemplateResponseCodeIds<Accounts>, anyhow::Result<AppResponse>> {
-//     let mut app = custom_mock_app();
-//     let (creator, buyer) = setup_accounts(&mut app);
-//     let collection_params = mock_collection_params_1(None);
-//     let code_ids = open_edition_minter_code_ids(&mut app);
-//     let minter_params = minter_params_open_edition(
-//         params_extension,
-//         init_msg,
-//         None,
-//         None,
-//         None,
-//         None,
-//         Some(custom_minter_params),
-//     );
-
-//     let minter_collection_response = configure_open_edition_minter(
-//         &mut app,
-//         creator.clone(),
-//         vec![collection_params],
-//         vec![minter_params],
-//         code_ids.clone(),
-//     );
-//     Ok(MinterTemplateResponseCodeIds {
-//         router: app,
-//         collection_response_vec: minter_collection_response,
-//         accts: Accounts { creator, buyer },
-//         code_ids,
-//     })
-// }

--- a/test-suite/src/common_setup/templates.rs
+++ b/test-suite/src/common_setup/templates.rs
@@ -1,4 +1,4 @@
-use crate::common_setup::contract_boxes::{contract_sg721_base, custom_mock_app};
+use crate::common_setup::contract_boxes::custom_mock_app;
 use crate::common_setup::msg::MinterTemplateResponse;
 use crate::common_setup::{
     msg::MinterCollectionResponse,
@@ -7,29 +7,25 @@ use crate::common_setup::{
     setup_minter::vending_minter::setup::{configure_minter, vending_minter_code_ids},
 };
 
-use crate::common_setup::setup_minter::base_minter::setup::base_minter_sg721_nt_code_ids;
-use crate::common_setup::setup_minter::base_minter::setup::configure_base_minter;
-use crate::common_setup::setup_minter::common::constants::{
-    CREATION_FEE, MIN_MINT_PRICE_OPEN_EDITION,
-};
-use crate::common_setup::setup_minter::common::parse_response::build_collection_response;
-use crate::common_setup::setup_minter::open_edition_minter::mock_params::{
-    mock_create_minter, mock_params_custom,
-};
-use crate::common_setup::setup_minter::open_edition_minter::setup::open_edition_minter_code_ids;
-use cosmwasm_std::{coin, coins, Coin, Timestamp, Uint128};
-use cw_multi_test::{AppResponse, Contract, Executor};
-use open_edition_factory::types::{NftData, NftMetadataType};
-use sg2::msg::Sg2ExecuteMsg;
-use sg2::tests::mock_collection_params_1;
-use sg_multi_test::StargazeApp;
-use sg_std::{StargazeMsgWrapper, GENESIS_MINT_START_TIME, NATIVE_DENOM};
-
-use super::msg::Accounts;
+use super::msg::{Accounts, CodeIds, MinterTemplateResponseCodeIds};
 use super::setup_minter::base_minter::setup::base_minter_sg721_collection_code_ids;
 use super::setup_minter::common::constants::{MINT_PRICE, MIN_MINT_PRICE};
 use super::setup_minter::common::minter_params::minter_params_all;
-use super::setup_minter::vending_minter::setup::vending_minter_updatable_code_ids;
+use super::setup_minter::open_edition_minter::setup::configure_open_edition_minter;
+use crate::common_setup::setup_accounts_and_block::CREATION_FEE;
+use crate::common_setup::setup_minter::base_minter::setup::base_minter_sg721_nt_code_ids;
+use crate::common_setup::setup_minter::base_minter::setup::configure_base_minter;
+use crate::common_setup::setup_minter::open_edition_minter::minter_params::minter_params_open_edition;
+use crate::common_setup::setup_minter::open_edition_minter::setup::open_edition_minter_code_ids;
+use crate::common_setup::setup_minter::vending_minter::setup::vending_minter_updatable_code_ids;
+use cosmwasm_std::{coin, Timestamp};
+use cw_multi_test::{AppResponse, BankSudo, SudoMsg};
+use open_edition_factory::msg::OpenEditionMinterInitMsgExtension;
+use open_edition_factory::state::{OpenEditionMinterParams, ParamsExtension};
+use open_edition_factory::types::NftData;
+use sg2::tests::{mock_collection_params_1, mock_collection_two};
+use sg_multi_test::StargazeApp;
+use sg_std::{GENESIS_MINT_START_TIME, NATIVE_DENOM};
 
 pub fn vending_minter_template(num_tokens: u32) -> MinterTemplateResponse<Accounts> {
     let mut app = custom_mock_app();
@@ -326,91 +322,270 @@ pub fn base_minter_with_specified_sg721(
     }
 }
 
-#[derive(Default)]
-pub struct OpenEditionMinterCustomParams<'a> {
-    pub denom: Option<&'a str>,
-    pub mint_fee_bps: Option<u64>,
-    pub airdrop_mint_price_amount: Option<Uint128>,
+pub fn open_edition_minter_custom_template(
+    params_extension: ParamsExtension,
+    init_msg: OpenEditionMinterInitMsgExtension,
+) -> Result<MinterTemplateResponseCodeIds<Accounts>, anyhow::Result<AppResponse>> {
+    let mut app = custom_mock_app();
+    let (creator, buyer) = setup_accounts(&mut app);
+    let code_ids = open_edition_minter_code_ids(&mut app);
+    let collection_params = mock_collection_params_1(None);
+    let minter_params =
+        minter_params_open_edition(params_extension, init_msg, None, None, None, None);
+
+    let minter_collection_response = configure_open_edition_minter(
+        &mut app,
+        creator.clone(),
+        vec![collection_params],
+        vec![minter_params],
+        code_ids.clone(),
+    );
+    println!(
+        "minter collection response is {:?}",
+        minter_collection_response[0].error
+    );
+    Ok(MinterTemplateResponseCodeIds {
+        router: app,
+        collection_response_vec: minter_collection_response,
+        accts: Accounts { creator, buyer },
+        code_ids,
+    })
 }
 
-// Custom params set to a high level function to ease the tests
-#[allow(clippy::too_many_arguments)]
-pub fn open_edition_minter_custom_template(
-    start_minter_time: Option<Timestamp>,
-    end_minter_time: Option<Timestamp>,
-    nft_data: Option<NftData>,
-    max_per_address_limit: Option<u32>,
-    per_address_limit_minter: Option<u32>,
-    mint_price_minter: Option<Coin>,
-    custom_params: OpenEditionMinterCustomParams,
-    sg721_code: Option<Box<dyn Contract<StargazeMsgWrapper>>>,
-    sg721_codeid: Option<u64>,
+pub fn open_edition_minter_nft_data(
+    params_extension: ParamsExtension,
+    init_msg: OpenEditionMinterInitMsgExtension,
+    nft_data: NftData,
 ) -> Result<MinterTemplateResponse<Accounts>, anyhow::Result<AppResponse>> {
     let mut app = custom_mock_app();
     let (creator, buyer) = setup_accounts(&mut app);
-    let code_ids =
-        open_edition_minter_code_ids(&mut app, sg721_code.unwrap_or_else(contract_sg721_base));
+    let code_ids = open_edition_minter_code_ids(&mut app);
+    let collection_params = mock_collection_params_1(None);
+    let minter_params =
+        minter_params_open_edition(params_extension, init_msg, None, None, Some(nft_data), None);
 
-    // Factory params
-    let mut factory_params = mock_params_custom(custom_params);
-    factory_params.extension.max_per_address_limit =
-        max_per_address_limit.unwrap_or(factory_params.extension.max_per_address_limit);
-
-    let factory_addr = app.instantiate_contract(
-        code_ids.factory_code_id,
+    let minter_collection_response = configure_open_edition_minter(
+        &mut app,
         creator.clone(),
-        &open_edition_factory::msg::InstantiateMsg {
-            params: factory_params,
-        },
-        &[],
-        "factory",
-        None,
+        vec![collection_params],
+        vec![minter_params],
+        code_ids,
     );
-
-    let factory_addr = factory_addr.unwrap();
-
-    // Minter -> Default params
-    let start_time = Timestamp::from_nanos(GENESIS_MINT_START_TIME + 100);
-    let end_time = Timestamp::from_nanos(GENESIS_MINT_START_TIME + 10_000);
-    let per_address_limit_minter = per_address_limit_minter.or(Some(1));
-    let mint_price = mint_price_minter.or_else(|| {
-        Some(Coin {
-            denom: NATIVE_DENOM.to_string(),
-            amount: Uint128::new(MIN_MINT_PRICE_OPEN_EDITION),
-        })
-    });
-    let collection_params = mock_collection_params_1(Some(start_time));
-    let default_nft_data = nft_data.unwrap_or(NftData {
-        nft_data_type: NftMetadataType::OffChainMetadata,
-        extension: None,
-        token_uri: Some(
-            "ipfs://bafybeiavall5udkxkdtdm4djezoxrmfc6o5fn2ug3ymrlvibvwmwydgrkm/1.jpg".to_string(),
-        ),
-    });
-    let mut msg = mock_create_minter(
-        start_minter_time.or(Some(start_time)),
-        end_minter_time.or(Some(end_time)),
-        mint_price,
-        per_address_limit_minter,
-        default_nft_data,
-        collection_params,
-        None,
-    );
-    msg.collection_params.code_id = sg721_codeid.unwrap_or(3);
-    msg.collection_params.info.creator = creator.to_string();
-    let creation_fee = coins(CREATION_FEE, NATIVE_DENOM);
-    let msg = Sg2ExecuteMsg::CreateMinter(msg);
-
-    let res = app.execute_contract(creator.clone(), factory_addr.clone(), &msg, &creation_fee);
-    if res.is_err() {
-        return Err(res);
-    }
-
-    let minter_collection_res = build_collection_response(res, factory_addr);
-
     Ok(MinterTemplateResponse {
         router: app,
-        collection_response_vec: vec![minter_collection_res],
+        collection_response_vec: minter_collection_response,
         accts: Accounts { creator, buyer },
     })
 }
+
+pub fn open_edition_minter_start_and_end_time(
+    params_extension: ParamsExtension,
+    init_msg: OpenEditionMinterInitMsgExtension,
+    start_time: Option<Timestamp>,
+    end_time: Option<Timestamp>,
+) -> Result<MinterTemplateResponse<Accounts>, anyhow::Result<AppResponse>> {
+    let mut app = custom_mock_app();
+    let (creator, buyer) = setup_accounts(&mut app);
+    let code_ids = open_edition_minter_code_ids(&mut app);
+    let collection_params = mock_collection_params_1(None);
+    let minter_params =
+        minter_params_open_edition(params_extension, init_msg, start_time, end_time, None, None);
+
+    let minter_collection_response = configure_open_edition_minter(
+        &mut app,
+        creator.clone(),
+        vec![collection_params],
+        vec![minter_params],
+        code_ids,
+    );
+    Ok(MinterTemplateResponse {
+        router: app,
+        collection_response_vec: minter_collection_response,
+        accts: Accounts { creator, buyer },
+    })
+}
+
+pub fn open_edition_minter_custom_code_ids(
+    app: StargazeApp,
+    params_extension: ParamsExtension,
+    init_msg: OpenEditionMinterInitMsgExtension,
+    code_ids: CodeIds,
+) -> Result<MinterTemplateResponse<Accounts>, anyhow::Result<AppResponse>> {
+    let mut app = app;
+    let (creator, buyer) = setup_accounts(&mut app);
+    let collection_params = mock_collection_params_1(None);
+    let minter_params =
+        minter_params_open_edition(params_extension, init_msg, None, None, None, None);
+
+    let minter_collection_response = configure_open_edition_minter(
+        &mut app,
+        creator.clone(),
+        vec![collection_params],
+        vec![minter_params],
+        code_ids,
+    );
+    Ok(MinterTemplateResponse {
+        router: app,
+        collection_response_vec: minter_collection_response,
+        accts: Accounts { creator, buyer },
+    })
+}
+
+pub fn base_minter_with_sudo_update_params_template(
+    num_tokens: u32,
+) -> MinterTemplateResponseCodeIds<Accounts> {
+    let mut app = custom_mock_app();
+    let (creator, buyer) = setup_accounts(&mut app);
+    let start_time = Timestamp::from_nanos(GENESIS_MINT_START_TIME);
+    let collection_params = mock_collection_params_1(Some(start_time));
+    let minter_params = minter_params_token(num_tokens);
+    let code_ids = base_minter_sg721_collection_code_ids(&mut app);
+    let minter_collection_response: Vec<MinterCollectionResponse> = configure_minter(
+        &mut app,
+        creator.clone(),
+        vec![collection_params],
+        vec![minter_params],
+        code_ids.clone(),
+    );
+    MinterTemplateResponseCodeIds {
+        router: app,
+        collection_response_vec: minter_collection_response,
+        accts: Accounts { creator, buyer },
+        code_ids,
+    }
+}
+
+pub fn vending_minter_template_with_code_ids_template(
+    num_tokens: u32,
+) -> MinterTemplateResponseCodeIds<Accounts> {
+    let mut app = custom_mock_app();
+    let (creator, buyer) = setup_accounts(&mut app);
+    let start_time = Timestamp::from_nanos(GENESIS_MINT_START_TIME);
+    let collection_params = mock_collection_params_1(Some(start_time));
+    let minter_params = minter_params_token(num_tokens);
+    let code_ids = vending_minter_code_ids(&mut app);
+    let minter_collection_response: Vec<MinterCollectionResponse> = configure_minter(
+        &mut app,
+        creator.clone(),
+        vec![collection_params],
+        vec![minter_params],
+        code_ids.clone(),
+    );
+    MinterTemplateResponseCodeIds {
+        router: app,
+        collection_response_vec: minter_collection_response,
+        accts: Accounts { creator, buyer },
+        code_ids,
+    }
+}
+
+pub fn open_edition_minter_with_two_sg721_collections_burn_mint(
+    params_extension: ParamsExtension,
+    init_msg: OpenEditionMinterInitMsgExtension,
+) -> Result<MinterTemplateResponse<Accounts>, anyhow::Result<AppResponse>> {
+    let mut router = custom_mock_app();
+    let (creator, buyer) = setup_accounts(&mut router);
+    router
+        .sudo(SudoMsg::Bank({
+            BankSudo::Mint {
+                to_address: creator.to_string(),
+                amount: vec![coin(CREATION_FEE * 2, NATIVE_DENOM)],
+            }
+        }))
+        .map_err(|err| println!("{:?}", err))
+        .ok();
+    let start_time = Timestamp::from_nanos(GENESIS_MINT_START_TIME);
+    let collection_params = mock_collection_params_1(Some(start_time));
+    let collection_params_2 = mock_collection_two(Some(start_time));
+    let minter_params = minter_params_open_edition(
+        params_extension.clone(),
+        init_msg.clone(),
+        None,
+        None,
+        None,
+        None,
+    );
+    let minter_params_2 =
+        minter_params_open_edition(params_extension, init_msg, None, None, None, None);
+    let code_ids = open_edition_minter_code_ids(&mut router);
+    let minter_collection_response = configure_open_edition_minter(
+        &mut router,
+        creator.clone(),
+        vec![collection_params, collection_params_2],
+        vec![minter_params, minter_params_2],
+        code_ids,
+    );
+    Ok(MinterTemplateResponse {
+        router,
+        collection_response_vec: minter_collection_response,
+        accts: Accounts { creator, buyer },
+    })
+}
+
+pub fn open_edition_minter_ibc_template(
+    params_extension: ParamsExtension,
+    init_msg: OpenEditionMinterInitMsgExtension,
+    custom_minter_params: OpenEditionMinterParams,
+) -> Result<MinterTemplateResponseCodeIds<Accounts>, anyhow::Result<AppResponse>> {
+    let mut app = custom_mock_app();
+    let (creator, buyer) = setup_accounts(&mut app);
+    let code_ids = open_edition_minter_code_ids(&mut app);
+    let collection_params = mock_collection_params_1(None);
+    let minter_params = minter_params_open_edition(
+        params_extension,
+        init_msg,
+        None,
+        None,
+        None,
+        Some(custom_minter_params),
+    );
+
+    let minter_collection_response = configure_open_edition_minter(
+        &mut app,
+        creator.clone(),
+        vec![collection_params],
+        vec![minter_params],
+        code_ids.clone(),
+    );
+    Ok(MinterTemplateResponseCodeIds {
+        router: app,
+        collection_response_vec: minter_collection_response,
+        accts: Accounts { creator, buyer },
+        code_ids,
+    })
+}
+
+// pub fn open_edition_minter_ibc_template_custom_code_ids(
+//     params_extension: ParamsExtension,
+//     init_msg: OpenEditionMinterInitMsgExtension,
+//     custom_minter_params: OpenEditionMinterParams,
+//     code_ids: CodeIds,
+// ) -> Result<MinterTemplateResponseCodeIds<Accounts>, anyhow::Result<AppResponse>> {
+//     let mut app = custom_mock_app();
+//     let (creator, buyer) = setup_accounts(&mut app);
+//     let collection_params = mock_collection_params_1(None);
+//     let code_ids = open_edition_minter_code_ids(&mut app);
+//     let minter_params = minter_params_open_edition(
+//         params_extension,
+//         init_msg,
+//         None,
+//         None,
+//         None,
+//         None,
+//         Some(custom_minter_params),
+//     );
+
+//     let minter_collection_response = configure_open_edition_minter(
+//         &mut app,
+//         creator.clone(),
+//         vec![collection_params],
+//         vec![minter_params],
+//         code_ids.clone(),
+//     );
+//     Ok(MinterTemplateResponseCodeIds {
+//         router: app,
+//         collection_response_vec: minter_collection_response,
+//         accts: Accounts { creator, buyer },
+//         code_ids,
+//     })
+// }

--- a/test-suite/src/open_edition_factory/tests.rs
+++ b/test-suite/src/open_edition_factory/tests.rs
@@ -1,3 +1,4 @@
 mod common;
 mod integration_tests;
 mod queries;
+mod sudo_tests;

--- a/test-suite/src/open_edition_factory/tests/common.rs
+++ b/test-suite/src/open_edition_factory/tests/common.rs
@@ -1,6 +1,5 @@
 use crate::common_setup::contract_boxes::{contract_open_edition_factory, custom_mock_app};
-use crate::common_setup::setup_minter::open_edition_minter::mock_params::mock_params_custom;
-use crate::common_setup::templates::OpenEditionMinterCustomParams;
+use crate::common_setup::setup_minter::open_edition_minter::mock_params::mock_params_proper;
 use cosmwasm_std::Addr;
 use cw_multi_test::Executor;
 use open_edition_factory::helpers::FactoryContract;
@@ -14,7 +13,7 @@ pub fn proper_instantiate() -> (StargazeApp, FactoryContract) {
     let factory_id = app.store_code(contract_open_edition_factory());
     let minter_id = 2;
 
-    let mut params = mock_params_custom(OpenEditionMinterCustomParams::default());
+    let mut params = mock_params_proper();
     params.code_id = minter_id;
 
     let factory_contract_addr = app

--- a/test-suite/src/open_edition_factory/tests/queries.rs
+++ b/test-suite/src/open_edition_factory/tests/queries.rs
@@ -9,8 +9,7 @@ mod tests {
     use sg_multi_test::StargazeApp;
 
     use crate::common_setup::contract_boxes::{contract_open_edition_factory, custom_mock_app};
-    use crate::common_setup::setup_minter::open_edition_minter::mock_params::mock_params_custom;
-    use crate::common_setup::templates::OpenEditionMinterCustomParams;
+    use crate::common_setup::setup_minter::open_edition_minter::mock_params::mock_params_proper;
 
     const GOVERNANCE: &str = "governance";
 
@@ -19,7 +18,7 @@ mod tests {
         let factory_id = app.store_code(contract_open_edition_factory());
         let minter_id = 2;
 
-        let mut params = mock_params_custom(OpenEditionMinterCustomParams::default());
+        let mut params = mock_params_proper();
         params.code_id = minter_id;
 
         let factory_contract_addr = app

--- a/test-suite/src/open_edition_factory/tests/sudo_tests.rs
+++ b/test-suite/src/open_edition_factory/tests/sudo_tests.rs
@@ -1,0 +1,88 @@
+use crate::common_setup::setup_minter::common::constants::DEV_ADDRESS;
+use crate::common_setup::setup_minter::open_edition_minter::minter_params::{
+    default_nft_data, init_msg,
+};
+use crate::common_setup::setup_minter::open_edition_minter::setup::sudo_update_params;
+use crate::common_setup::templates::open_edition_minter_custom_template;
+use base_factory::msg::ParamsResponse;
+use cosmwasm_std::{coin, Coin, Uint128};
+use open_edition_factory::msg::OpenEditionUpdateParamsExtension;
+use open_edition_factory::state::ParamsExtension;
+use sg2::query::Sg2QueryMsg::Params;
+use sg_std::NATIVE_DENOM;
+
+#[test]
+fn happy_path_with_params_update() {
+    let params_extension = ParamsExtension {
+        max_per_address_limit: 10,
+        airdrop_mint_fee_bps: 100,
+        airdrop_mint_price: Coin {
+            denom: NATIVE_DENOM.to_string(),
+            amount: Uint128::new(100_000_000u128),
+        },
+        dev_fee_address: DEV_ADDRESS.to_string(),
+    };
+    let per_address_limit_minter = Some(2);
+    let init_msg = init_msg(
+        default_nft_data(),
+        per_address_limit_minter,
+        None,
+        None,
+        None,
+    );
+    let vt = open_edition_minter_custom_template(params_extension, init_msg).unwrap();
+    let mut router = vt.router;
+    sudo_update_params(&mut router, &vt.collection_response_vec, vt.code_ids, None);
+}
+
+#[test]
+fn sudo_params_update_creation_fee() {
+    let params_extension = ParamsExtension {
+        max_per_address_limit: 10,
+        airdrop_mint_fee_bps: 100,
+        airdrop_mint_price: Coin {
+            denom: NATIVE_DENOM.to_string(),
+            amount: Uint128::new(100_000_000u128),
+        },
+        dev_fee_address: DEV_ADDRESS.to_string(),
+    };
+    let per_address_limit_minter = Some(2);
+    let init_msg = init_msg(
+        default_nft_data(),
+        per_address_limit_minter,
+        None,
+        None,
+        None,
+    );
+    let vt = open_edition_minter_custom_template(params_extension, init_msg).unwrap();
+    let factory = vt.collection_response_vec[0].factory.clone().unwrap();
+    let code_ids = vt.code_ids.clone();
+    let mut router = vt.router;
+
+    let update_msg = sg2::msg::UpdateMinterParamsMsg {
+        code_id: Some(code_ids.sg721_code_id),
+        add_sg721_code_ids: None,
+        rm_sg721_code_ids: None,
+        frozen: None,
+        creation_fee: Some(coin(999, NATIVE_DENOM)),
+        min_mint_price: Some(coin(10, NATIVE_DENOM)),
+        mint_fee_bps: None,
+        max_trading_offset_secs: Some(100),
+        extension: OpenEditionUpdateParamsExtension {
+            min_mint_price: Some(coin(10, NATIVE_DENOM)),
+            max_per_address_limit: None,
+            airdrop_mint_price: None,
+            airdrop_mint_fee_bps: None,
+            dev_fee_address: Some(DEV_ADDRESS.to_string()),
+        },
+    };
+    sudo_update_params(
+        &mut router,
+        &vt.collection_response_vec,
+        vt.code_ids,
+        Some(update_msg),
+    );
+
+    let res: ParamsResponse = router.wrap().query_wasm_smart(factory, &Params {}).unwrap();
+    assert_eq!(res.params.creation_fee, coin(999, NATIVE_DENOM));
+}

--- a/test-suite/src/open_edition_minter/tests/address_limit.rs
+++ b/test-suite/src/open_edition_minter/tests/address_limit.rs
@@ -1,31 +1,41 @@
-use cosmwasm_std::coins;
+use cosmwasm_std::{coins, Coin, Uint128};
 use cw_multi_test::Executor;
+use open_edition_factory::state::ParamsExtension;
 use sg_std::{GENESIS_MINT_START_TIME, NATIVE_DENOM};
 
 use open_edition_minter::msg::ConfigResponse;
 use open_edition_minter::msg::{ExecuteMsg, QueryMsg};
 
 use crate::common_setup::setup_accounts_and_block::setup_block_time;
-use crate::common_setup::templates::{
-    open_edition_minter_custom_template, OpenEditionMinterCustomParams,
+use crate::common_setup::setup_minter::common::constants::DEV_ADDRESS;
+use crate::common_setup::setup_minter::open_edition_minter::minter_params::{
+    default_nft_data, init_msg,
 };
+use crate::common_setup::templates::open_edition_minter_custom_template;
 
 const MINT_PRICE: u128 = 100_000_000;
 
 #[test]
 fn check_per_address_limit() {
-    let vt = open_edition_minter_custom_template(
+    let params_extension = ParamsExtension {
+        max_per_address_limit: 10,
+        airdrop_mint_fee_bps: 100,
+        airdrop_mint_price: Coin {
+            denom: NATIVE_DENOM.to_string(),
+            amount: Uint128::new(100_000_000u128),
+        },
+        dev_fee_address: DEV_ADDRESS.to_string(),
+    };
+    let per_address_limit_minter = Some(2);
+    let init_msg = init_msg(
+        default_nft_data(),
+        per_address_limit_minter,
         None,
         None,
         None,
-        Some(10),
-        Some(2),
-        None,
-        OpenEditionMinterCustomParams::default(),
-        None,
-        None,
-    )
-    .unwrap();
+    );
+    let vt = open_edition_minter_custom_template(params_extension, init_msg).unwrap();
+
     let (mut router, creator, buyer) = (vt.router, vt.accts.creator, vt.accts.buyer);
     let minter_addr = vt.collection_response_vec[0].minter.clone().unwrap();
     // Set to a valid mint time

--- a/test-suite/src/open_edition_minter/tests/allowed_code_ids.rs
+++ b/test-suite/src/open_edition_minter/tests/allowed_code_ids.rs
@@ -1,32 +1,50 @@
-use crate::common_setup::templates::{
-    open_edition_minter_custom_template, OpenEditionMinterCustomParams,
+use cosmwasm_std::{Coin, Uint128};
+use open_edition_factory::state::ParamsExtension;
+use sg_std::NATIVE_DENOM;
+
+use crate::common_setup::{
+    contract_boxes::custom_mock_app,
+    setup_minter::{
+        common::constants::DEV_ADDRESS,
+        open_edition_minter::{
+            minter_params::{default_nft_data, init_msg},
+            setup::open_edition_minter_code_ids,
+        },
+    },
+    templates::open_edition_minter_custom_code_ids,
 };
 
 #[test]
 fn invalid_code_id() {
-    // Set an invalid code id for the nft contract
-    let vt = open_edition_minter_custom_template(
+    let params_extension = ParamsExtension {
+        max_per_address_limit: 10,
+        airdrop_mint_fee_bps: 100,
+        airdrop_mint_price: Coin {
+            denom: NATIVE_DENOM.to_string(),
+            amount: Uint128::new(100_000_000u128),
+        },
+        dev_fee_address: DEV_ADDRESS.to_string(),
+    };
+    let per_address_limit_minter = Some(2);
+    let init_msg = init_msg(
+        default_nft_data(),
+        per_address_limit_minter,
         None,
         None,
         None,
-        Some(10),
-        Some(5),
-        None,
-        OpenEditionMinterCustomParams::default(),
-        None,
-        Some(19),
     );
+    let mut app = custom_mock_app();
+    let mut code_ids = open_edition_minter_code_ids(&mut app);
+    code_ids.sg721_code_id = 19;
+    let vt =
+        open_edition_minter_custom_code_ids(app, params_extension, init_msg, code_ids).unwrap();
     assert_eq!(
-        vt.err()
+        vt.collection_response_vec[0]
+            .error
+            .as_ref()
             .unwrap()
-            .err()
-            .unwrap()
-            .source()
-            .unwrap()
+            .root_cause()
             .to_string(),
         "InvalidCollectionCodeId 19".to_string()
     );
-
-    // All the other tests related to Sudo params of the factory contract are tested in the factory
-    // tests
 }

--- a/test-suite/src/open_edition_minter/tests/complete_mint_all_outcomes_validation.rs
+++ b/test-suite/src/open_edition_minter/tests/complete_mint_all_outcomes_validation.rs
@@ -1,6 +1,7 @@
 use cosmwasm_std::{coins, Coin, Timestamp, Uint128};
 use cw721::{Cw721QueryMsg, NumTokensResponse, OwnerOfResponse};
 use cw_multi_test::{BankSudo, Executor, SudoMsg};
+use open_edition_factory::state::ParamsExtension;
 use sg_std::{GENESIS_MINT_START_TIME, NATIVE_DENOM};
 
 use open_edition_minter::msg::{EndTimeResponse, ExecuteMsg, QueryMsg, TotalMintCountResponse};
@@ -9,26 +10,34 @@ use sg4::StatusResponse;
 
 use crate::common_setup::setup_accounts_and_block::{coins_for_msg, setup_block_time};
 use crate::common_setup::setup_minter::common::constants::DEV_ADDRESS;
-use crate::common_setup::templates::{
-    open_edition_minter_custom_template, OpenEditionMinterCustomParams,
+use crate::common_setup::setup_minter::open_edition_minter::minter_params::{
+    default_nft_data, init_msg,
 };
+use crate::common_setup::templates::open_edition_minter_custom_template;
 
 const MINT_PRICE: u128 = 100_000_000;
 
 #[test]
 fn check_mint_revenues_distribution() {
-    let vt = open_edition_minter_custom_template(
+    let params_extension = ParamsExtension {
+        max_per_address_limit: 10,
+        airdrop_mint_fee_bps: 100,
+        airdrop_mint_price: Coin {
+            denom: NATIVE_DENOM.to_string(),
+            amount: Uint128::new(100_000_000u128),
+        },
+        dev_fee_address: DEV_ADDRESS.to_string(),
+    };
+    let per_address_limit_minter = Some(3);
+    let init_msg = init_msg(
+        default_nft_data(),
+        per_address_limit_minter,
         None,
         None,
         None,
-        None,
-        Some(3),
-        None,
-        OpenEditionMinterCustomParams::default(),
-        None,
-        None,
-    )
-    .unwrap();
+    );
+    let vt = open_edition_minter_custom_template(params_extension, init_msg).unwrap();
+
     let (mut router, creator, buyer) = (vt.router, vt.accts.creator, vt.accts.buyer);
     let minter_addr = vt.collection_response_vec[0].minter.clone().unwrap();
     let collection_addr = vt.collection_response_vec[0].collection.clone().unwrap();
@@ -119,7 +128,7 @@ fn check_mint_revenues_distribution() {
                 amount: coins(100_000u128, "invalid".to_string()),
             }
         }))
-        .map_err(|err| println!("{err:?}"))
+        .map_err(|err| println!("{:?}", err))
         .ok();
     let mint_msg = ExecuteMsg::Mint {};
     let res = router.execute_contract(

--- a/test-suite/src/open_edition_minter/tests/frozen_factory.rs
+++ b/test-suite/src/open_edition_minter/tests/frozen_factory.rs
@@ -1,5 +1,6 @@
 use cosmwasm_std::{coins, Coin, Timestamp, Uint128};
 use cw_multi_test::{BankSudo, Executor, SudoMsg};
+use open_edition_factory::state::ParamsExtension;
 use sg_std::{GENESIS_MINT_START_TIME, NATIVE_DENOM};
 
 use open_edition_factory::msg::{OpenEditionUpdateParamsExtension, OpenEditionUpdateParamsMsg};
@@ -7,27 +8,28 @@ use open_edition_factory::types::{NftData, NftMetadataType};
 use sg2::msg::Sg2ExecuteMsg;
 use sg2::tests::mock_collection_params_1;
 
-use crate::common_setup::setup_minter::common::constants::CREATION_FEE;
 use crate::common_setup::setup_minter::common::constants::MIN_MINT_PRICE_OPEN_EDITION;
-use crate::common_setup::setup_minter::open_edition_minter::mock_params::mock_create_minter;
-use crate::common_setup::templates::{
-    open_edition_minter_custom_template, OpenEditionMinterCustomParams,
+use crate::common_setup::setup_minter::common::constants::{CREATION_FEE, DEV_ADDRESS};
+use crate::common_setup::setup_minter::open_edition_minter::minter_params::{
+    default_nft_data, init_msg,
 };
+use crate::common_setup::setup_minter::open_edition_minter::mock_params::mock_create_minter;
+use crate::common_setup::templates::open_edition_minter_custom_template;
 
 #[test]
 fn frozen_factory_cannot_create_new_minters() {
-    let vt = open_edition_minter_custom_template(
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        OpenEditionMinterCustomParams::default(),
-        None,
-        None,
-    )
-    .unwrap();
+    let params_extension = ParamsExtension {
+        max_per_address_limit: 10,
+        airdrop_mint_fee_bps: 100,
+        airdrop_mint_price: Coin {
+            denom: NATIVE_DENOM.to_string(),
+            amount: Uint128::new(100_000_000u128),
+        },
+        dev_fee_address: DEV_ADDRESS.to_string(),
+    };
+    let init_msg = init_msg(default_nft_data(), None, None, None, None);
+    let vt = open_edition_minter_custom_template(params_extension, init_msg).unwrap();
+
     let (mut router, creator, _buyer) = (vt.router, vt.accts.creator, vt.accts.buyer);
     let _minter_addr = vt.collection_response_vec[0].minter.clone().unwrap();
     let factory_addr = vt.collection_response_vec[0].factory.clone().unwrap();
@@ -49,6 +51,7 @@ fn frozen_factory_cannot_create_new_minters() {
             dev_fee_address: None,
         },
     };
+
     let sudo_msg = open_edition_factory::msg::SudoMsg::UpdateParams(Box::new(update_msg));
     let _res = router.wasm_sudo(factory_addr.clone(), &sudo_msg);
 
@@ -88,7 +91,7 @@ fn frozen_factory_cannot_create_new_minters() {
                 amount: coins(CREATION_FEE, NATIVE_DENOM),
             }
         }))
-        .map_err(|err| println!("{err:?}"))
+        .map_err(|err| println!("{:?}", err))
         .ok();
     let res = router.execute_contract(creator, factory_addr, &msg, &creation_fee);
     assert_eq!(

--- a/test-suite/src/open_edition_minter/tests/update_mint_price.rs
+++ b/test-suite/src/open_edition_minter/tests/update_mint_price.rs
@@ -1,30 +1,40 @@
 use cosmwasm_std::{Coin, Uint128};
 use cw_multi_test::Executor;
+use open_edition_factory::state::ParamsExtension;
 use sg_std::{GENESIS_MINT_START_TIME, NATIVE_DENOM};
 
 use open_edition_minter::msg::{ExecuteMsg, QueryMsg};
 
 use crate::common_setup::setup_accounts_and_block::setup_block_time;
-use crate::common_setup::templates::{
-    open_edition_minter_custom_template, OpenEditionMinterCustomParams,
+use crate::common_setup::setup_minter::common::constants::DEV_ADDRESS;
+use crate::common_setup::setup_minter::open_edition_minter::minter_params::{
+    default_nft_data, init_msg,
 };
+use crate::common_setup::templates::open_edition_minter_custom_template;
 
 const MINT_PRICE: u128 = 100_000_000;
 
 #[test]
 fn check_mint_price_updates() {
-    let vt = open_edition_minter_custom_template(
+    let params_extension = ParamsExtension {
+        max_per_address_limit: 10,
+        airdrop_mint_fee_bps: 100,
+        airdrop_mint_price: Coin {
+            denom: NATIVE_DENOM.to_string(),
+            amount: Uint128::new(100_000_000u128),
+        },
+        dev_fee_address: DEV_ADDRESS.to_string(),
+    };
+    let per_address_limit_minter = Some(2);
+    let init_msg = init_msg(
+        default_nft_data(),
+        per_address_limit_minter,
         None,
         None,
         None,
-        Some(10),
-        Some(2),
-        None,
-        OpenEditionMinterCustomParams::default(),
-        None,
-        None,
-    )
-    .unwrap();
+    );
+
+    let vt = open_edition_minter_custom_template(params_extension, init_msg).unwrap();
     let (mut router, creator, _buyer) = (vt.router, vt.accts.creator, vt.accts.buyer);
     let minter_addr = vt.collection_response_vec[0].minter.clone().unwrap();
 
@@ -41,6 +51,7 @@ fn check_mint_price_updates() {
             amount: Uint128::new(MINT_PRICE)
         }
     );
+
     assert_eq!(
         res.airdrop_price,
         Coin {

--- a/test-suite/src/open_edition_minter/tests/update_start_and_end_time.rs
+++ b/test-suite/src/open_edition_minter/tests/update_start_and_end_time.rs
@@ -1,28 +1,37 @@
-use cosmwasm_std::Timestamp;
+use cosmwasm_std::{Coin, Timestamp, Uint128};
 use cw_multi_test::Executor;
-use sg_std::GENESIS_MINT_START_TIME;
+use open_edition_factory::state::ParamsExtension;
+use sg_std::{GENESIS_MINT_START_TIME, NATIVE_DENOM};
 
 use open_edition_minter::msg::{EndTimeResponse, StartTimeResponse};
 use open_edition_minter::msg::{ExecuteMsg, QueryMsg};
 
-use crate::common_setup::templates::{
-    open_edition_minter_custom_template, OpenEditionMinterCustomParams,
+use crate::common_setup::setup_minter::common::constants::DEV_ADDRESS;
+use crate::common_setup::setup_minter::open_edition_minter::minter_params::{
+    default_nft_data, init_msg,
 };
+use crate::common_setup::templates::open_edition_minter_custom_template;
 
 #[test]
 fn check_start_end_time_updates() {
-    let vt = open_edition_minter_custom_template(
+    let params_extension = ParamsExtension {
+        max_per_address_limit: 10,
+        airdrop_mint_fee_bps: 100,
+        airdrop_mint_price: Coin {
+            denom: NATIVE_DENOM.to_string(),
+            amount: Uint128::new(100_000_000u128),
+        },
+        dev_fee_address: DEV_ADDRESS.to_string(),
+    };
+    let per_address_limit_minter = Some(2);
+    let init_msg = init_msg(
+        default_nft_data(),
+        per_address_limit_minter,
         None,
         None,
         None,
-        Some(10),
-        Some(2),
-        None,
-        OpenEditionMinterCustomParams::default(),
-        None,
-        None,
-    )
-    .unwrap();
+    );
+    let vt = open_edition_minter_custom_template(params_extension, init_msg).unwrap();
     let (mut router, creator, _buyer) = (vt.router, vt.accts.creator, vt.accts.buyer);
     let minter_addr = vt.collection_response_vec[0].minter.clone().unwrap();
 

--- a/test-suite/src/vending_factory/tests.rs
+++ b/test-suite/src/vending_factory/tests.rs
@@ -1,1 +1,2 @@
 mod integration_tests;
+mod sudo_tests;

--- a/test-suite/src/vending_factory/tests/sudo_tests.rs
+++ b/test-suite/src/vending_factory/tests/sudo_tests.rs
@@ -1,0 +1,51 @@
+use base_factory::msg::ParamsResponse;
+use cosmwasm_std::coin;
+use sg_std::NATIVE_DENOM;
+use vending_factory::msg::VendingUpdateParamsExtension;
+
+use crate::common_setup::setup_minter::base_minter::mock_params::MIN_MINT_PRICE;
+use crate::common_setup::setup_minter::vending_minter::setup::sudo_update_params;
+use crate::common_setup::templates::vending_minter_template_with_code_ids_template;
+use sg2::query::Sg2QueryMsg::Params;
+
+#[test]
+fn happy_path_with_params_update() {
+    let vt = vending_minter_template_with_code_ids_template(2);
+    let (mut router, _, _) = (vt.router, vt.accts.creator, vt.accts.buyer);
+    sudo_update_params(&mut router, &vt.collection_response_vec, vt.code_ids, None);
+}
+
+#[test]
+fn sudo_params_update_creation_fee() {
+    let vt = vending_minter_template_with_code_ids_template(2);
+    let (mut router, _, _) = (vt.router, vt.accts.creator, vt.accts.buyer);
+    let factory = vt.collection_response_vec[0].factory.clone().unwrap();
+    let code_ids = vt.code_ids.clone();
+
+    let update_msg = sg2::msg::UpdateMinterParamsMsg {
+        code_id: Some(code_ids.sg721_code_id),
+        add_sg721_code_ids: None,
+        rm_sg721_code_ids: None,
+        frozen: None,
+        creation_fee: Some(coin(999, NATIVE_DENOM)),
+        min_mint_price: Some(coin(MIN_MINT_PRICE, NATIVE_DENOM)),
+        mint_fee_bps: None,
+        max_trading_offset_secs: Some(100),
+        extension: VendingUpdateParamsExtension {
+            max_token_limit: None,
+            max_per_address_limit: None,
+            airdrop_mint_price: None,
+            airdrop_mint_fee_bps: None,
+            shuffle_fee: None,
+        },
+    };
+    sudo_update_params(
+        &mut router,
+        &vt.collection_response_vec,
+        vt.code_ids,
+        Some(update_msg),
+    );
+
+    let res: ParamsResponse = router.wrap().query_wasm_smart(factory, &Params {}).unwrap();
+    assert_eq!(res.params.creation_fee, coin(999, NATIVE_DENOM));
+}


### PR DESCRIPTION
Porting this from burn to mint closed PR. 
In that PR I did a refactor of all the open edition minter tests. 
Now with that PR closed, I am porting over to main so we don't lose the refactor, while we are waiting for the new burn to mint. 

Additionally, I had written updates for sudo tests for base_factory, open_edition_factory and vending_factory, these tests have been added to this PR. 