### PR TITLE
Add `cw-ownable` to minters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,6 +300,7 @@ dependencies = [
  "base-factory",
  "cosmwasm-schema",
  "cosmwasm-std",
+ "cw-ownable",
  "cw-storage-plus 1.1.0",
  "cw-utils 1.0.1",
  "cw2 1.1.0",

--- a/contracts/collections/sg721-base/src/contract.rs
+++ b/contracts/collections/sg721-base/src/contract.rs
@@ -246,14 +246,12 @@ where
 
                     if share_delta > Decimal::percent(MAX_SHARE_DELTA_PCT) {
                         return Err(ContractError::InvalidRoyalties(format!(
-                            "Share increase cannot be greater than {}%",
-                            MAX_SHARE_DELTA_PCT
+                            "Share increase cannot be greater than {MAX_SHARE_DELTA_PCT}%"
                         )));
                     }
                     if new_royalty_info.share > Decimal::percent(MAX_ROYALTY_SHARE_PCT) {
                         return Err(ContractError::InvalidRoyalties(format!(
-                            "Share cannot be greater than {}%",
-                            MAX_ROYALTY_SHARE_PCT
+                            "Share cannot be greater than {MAX_ROYALTY_SHARE_PCT}%"
                         )));
                     }
                 }

--- a/contracts/minters/base-minter/Cargo.toml
+++ b/contracts/minters/base-minter/Cargo.toml
@@ -32,6 +32,7 @@ cosmwasm-std    = { workspace = true }
 cw2             = { workspace = true }
 cw721           = { workspace = true }
 cw721-base      = { workspace = true, features = ["library"] }
+cw-ownable      = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw-utils        = { workspace = true }
 schemars        = { workspace = true }

--- a/contracts/minters/base-minter/src/error.rs
+++ b/contracts/minters/base-minter/src/error.rs
@@ -21,6 +21,9 @@ pub enum ContractError {
     #[error("Unauthorized: {0}")]
     Unauthorized(String),
 
+    #[error("{0}")]
+    Ownership(#[from] cw_ownable::OwnershipError),
+
     #[error("UpdateStatus")]
     UpdateStatus {},
 

--- a/contracts/minters/base-minter/src/msg.rs
+++ b/contracts/minters/base-minter/src/msg.rs
@@ -1,7 +1,7 @@
 use base_factory::{msg::BaseMinterCreateMsg, state::BaseMinterParams};
-use cosmwasm_schema::cw_serde;
+use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Empty, Timestamp};
-use sg4::MinterConfigResponse;
+use sg4::{MinterConfigResponse, StatusResponse};
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -9,6 +9,7 @@ pub struct InstantiateMsg {
     pub params: BaseMinterParams,
 }
 
+#[cw_ownable::cw_ownable_execute]
 #[cw_serde]
 pub enum ExecuteMsg {
     Mint { token_uri: String },
@@ -16,3 +17,13 @@ pub enum ExecuteMsg {
 }
 
 pub type ConfigResponse = MinterConfigResponse<Empty>;
+
+#[cw_ownable::cw_ownable_query]
+#[cw_serde]
+#[derive(QueryResponses)]
+pub enum QueryMsg {
+    #[returns(ConfigResponse)]
+    Config {},
+    #[returns(StatusResponse)]
+    Status {},
+}

--- a/packages/sg2/src/msg.rs
+++ b/packages/sg2/src/msg.rs
@@ -4,6 +4,7 @@ use sg721::{CollectionInfo, RoyaltyInfoResponse};
 
 #[cw_serde]
 pub struct CreateMinterMsg<T> {
+    pub owner: String,
     pub init_msg: T,
     pub collection_params: CollectionParams,
 }

--- a/packages/sg4/src/lib.rs
+++ b/packages/sg4/src/lib.rs
@@ -4,6 +4,7 @@ use cosmwasm_std::{Addr, Coin};
 /// Saved in every minter
 #[cw_serde]
 pub struct MinterConfig<T> {
+    pub owner: Addr,
     pub factory: Addr,
     pub collection_code_id: u64,
     pub mint_price: Coin,


### PR DESCRIPTION
A first in a series of steps to fix minter/collection ownership transfers.

Step 1: Add `cw-ownable` to minters. << ***This PR*** >>
Step 2: Make collection owners to be minters.  (See https://github.com/public-awesome/launchpad/pull/603)
Step 3: Pass through collection writes (not just mints) through minter

Minters basically become collection controllers. This moves Launchpad to a "Fat minter, thin collection" model. It enables standardizing collections to make things easier as Stargaze onboards collections from other chains. Ownership is delegated from minter to collection. With a minter attached, collections are mutable. Without a minter, collections are immutable.

## TODO

- [ ] Add `cw-ownable` to other minters
- [ ] Fix tests