### PR TITLE
docs: update dead link

### DIFF
--- a/packages/controllers/README.md
+++ b/packages/controllers/README.md
@@ -6,4 +6,4 @@ style, where it is an element that encapsulated business logic and data access.
 We can also directly handle some `ExecuteMsg` and `QueryMsg` variants by
 adding a sub-router to these controllers.
 
-This work is derived from [cw-plus](https://github.com/CosmWasm/cw-plus/tree/main/packages/controllers).
+This work is derived from [cw-minus](https://github.com/CosmWasm/cw-minus/tree/main/packages/controllers).


### PR DESCRIPTION
## PR Description

This PR updates the documentation to reflect the changes introduced in [#894](https://github.com/CosmWasm/cw-plus/pull/894), which moved the `controllers` package from the `cw-plus` repository to the `cw-minus` repository.

The reference in `packages/controllers/README.md` has been updated to point to the new location in `cw-minus`:
- Old: https://github.com/CosmWasm/cw-plus/tree/main/packages/controllers
- New: https://github.com/CosmWasm/cw-minus/tree/main/packages/controllers

This ensures that documentation links remain accurate and up-to-date after the package migration.